### PR TITLE
水上機母艦の砲撃戦火力および対潜火力修正(暫定対処)

### DIFF
--- a/script/ship_power.js
+++ b/script/ship_power.js
@@ -17,7 +17,7 @@ function body(ship) {
 	switch (ship.stype) {
 	case 7: // 軽空母
 	case 11: // 正規空母
-	case 16: // 水上機母艦
+//	case 16: // 水上機母艦  ※水上機母艦は砲撃艦のためコメントアウト
 	case 18: // 装甲空母
 		// (火力 + 雷装) × 1.5 + 爆装 × 2 + 55
 		var rai = ship.slotParam.raig;
@@ -29,10 +29,34 @@ function body(ship) {
 		break;
 	}
 
-	// 対潜 = [ 艦船の対潜 ÷ 5 ] + 装備の対潜 × 2 + 25
+	// 対潜 = [ 艦船の対潜 ÷ 5 ] + 装備の対潜 × 2 + 対潜基本値(爆雷攻撃艦=25,艦載機運用艦=10) 
 	var taisenItem = ship.slotParam.taisen;
 	var taisenShip = ship.taisen - taisenItem;
-	var taisenPower = Math.floor(taisenShip / 5) + (taisenItem * 2) + 25;
+	var taisenBasicPower = 0;
+	
+	switch (ship.stype) {
+	case 2: // 駆逐艦
+	case 3: // 軽巡洋艦
+	case 21: // 練習巡洋艦
+		// 爆雷攻撃艦＝対潜基本値25
+		taisenBasicPower = 25;
+		break;
+	case 6: // 航空巡洋艦
+	case 7: // 軽空母
+	case 10: // 航空戦艦
+	case 16: // 水上機母艦
+	case 17: // 揚陸艦
+	case 19: // 工作艦
+		// 艦載機運用艦＝対潜基本値10
+		taisenBasicPower = 10;
+		break;
+	default:
+		taisenBasicPower = 0;
+		break;
+	}
+	
+			
+	var taisenPower = Math.floor(taisenShip / 5) + (taisenItem * 2) + taisenBasicPower;
 
 	return toComparable([
 					ship.slotParam.houm, // 装備命中


### PR DESCRIPTION
１．水上機母艦の砲撃戦火力を空母式から砲撃艦式になる様に変更。
２．対潜火力の追加加算分を以下に変更。
駆逐艦・軽巡洋艦・練習巡洋艦＝25
航空巡洋艦・軽空母・航空戦艦・水上機母艦・揚陸艦・工作艦=10
対潜攻撃不可＝0

対潜火力は暫定処置のため以下の点が主流の検証結果と異なります。
１．水偵の対潜値も加算しています。
２．対潜攻撃不可でも計算されます。