### PR TITLE
機能追加再修正

### DIFF
--- a/main/logbook/gui/logic/BattleHtmlGenerator.java
+++ b/main/logbook/gui/logic/BattleHtmlGenerator.java
@@ -1,3 +1,4 @@
+
 /**
  *
  */
@@ -7,6 +8,7 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -157,8 +159,8 @@ public class BattleHtmlGenerator extends HTMLGenerator {
         this.inline("th", "cond.", null);
         this.inline("th", "制空", null);
         this.inline("th", "索敵", null);
-        this.inline("th", "割合撃墜", null);
-        this.inline("th", "固定撃墜<br>(対空CI補正前)", null);
+        this.inline("th", "加重対空値", null);
+        this.inline("th", "艦隊防空値", null);
         this.inline("th", "開始時", null);
         for (int i = 0; i < numPhases; ++i) {
             this.inline("th", "", null);
@@ -182,12 +184,13 @@ public class BattleHtmlGenerator extends HTMLGenerator {
 
         int totalNowHp = 0;
         int totalMaxHp = 0;
+        CalcTaiku calcTaiku = new CalcTaiku();
+        int formationNo = BattleExDto.fromFormation(formation[isFriend ? 0 : 1]);
 
         for (int i = 0; i < ships.size(); ++i) {
             SHIP ship = ships.get(i);
             SeikuString seiku = new SeikuString(ship);
             SakutekiString sakuteki = new SakutekiString(ship);
-            CalcTaiku calcTaiku = new CalcTaiku();
             int nowhp = hp[0][i];
             int maxhp = hp[1][i];
 
@@ -207,11 +210,9 @@ public class BattleHtmlGenerator extends HTMLGenerator {
 
             this.inline("td", seiku.toString(), null);
             this.inline("td", sakuteki.toString(), null);
-            this.inline("td", String.format("%.2f%%", calcTaiku.getProportionalShootDown(ship) * 100), null);
-            this.inline("td", String.format("%d",
-                    calcTaiku.getFixedShootDown(ship, allShips,
-                            BattleExDto.fromFormation(formation[isFriend ? 0 : 1]))),
-                    null);
+            this.inline("td", String.format("%d", calcTaiku.getKajuuValue(ship)), null);
+            this.inline("td", String.format("+%.2f",
+                    calcTaiku.getKantaiValue(new ArrayList<SHIP>(Arrays.asList(ship)), formationNo)), null);
             this.inline("td", nowhp + "/" + maxhp, null);
 
             for (int p = 1; p <= numPhases; ++p) {
@@ -250,7 +251,7 @@ public class BattleHtmlGenerator extends HTMLGenerator {
         this.inline("td", totalSeiku.toString(), null);
         this.inline("td", totalSakuteki.toString(), null);
         this.inline("td", "", null);
-        this.inline("td", "", null);
+        this.inline("td", String.format("%.2f", calcTaiku.getKantaiValue(allShips, formationNo)), null);
         this.inline("td", totalNowHp + "/" + totalMaxHp, null);
 
         for (int i = 0; i < numPhases; ++i) {

--- a/main/logbook/gui/logic/CalcTaiku.java
+++ b/main/logbook/gui/logic/CalcTaiku.java
@@ -94,8 +94,8 @@ public class CalcTaiku {
             List<ItemDto> items = ship.getItem2();
 
             // 各艦の艦隊対空ボーナス値
-            int shipBonus = (int) items.stream().filter(item -> item != null)
-                    .mapToDouble(item -> {
+            int shipBonus = items.stream().filter(item -> item != null)
+                    .mapToInt(item -> {
                         // 種別
                         int type3 = item.getType3();
                         // 装備倍率
@@ -107,8 +107,9 @@ public class CalcTaiku {
                         // 装備改修値
                         int level = item.getLevel();
 
-                        return (magnification * taik) + (factor * Math.sqrt(level));
-                    }).sum();
+                        // 浮動小数点の合算で誤差が生じるため、100倍してから100で割る
+                        return (int) (((magnification * taik) + (factor * Math.sqrt(level))) * 100);
+                    }).sum() / 100;
             return shipBonus;
         }).sum();
 

--- a/main/logbook/gui/logic/CalcTaiku.java
+++ b/main/logbook/gui/logic/CalcTaiku.java
@@ -159,7 +159,18 @@ public class CalcTaiku {
     }
 
     /**
-     * 割合撃墜数を返します。
+     * 割合撃墜数を返します。(連合艦隊専用)
+     *
+     * @param ship 艦娘
+     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @return value 割合撃墜数
+     */
+    public <SHIP extends ShipBaseDto> double getProportionalShootDownCombined(SHIP ship, int combinedKind) {
+        return this.getProportionalShootDownCombined(this.getKajuuValue(ship), combinedKind);
+    }
+
+    /**
+     * 割合撃墜数を返します。(通常艦隊専用)
      *
      * @param ship 艦娘
      * @return value 割合撃墜数
@@ -169,18 +180,48 @@ public class CalcTaiku {
     }
 
     /**
-     * 割合撃墜数を返します。
+     * 割合撃墜数を返します。(連合艦隊専用)
+     *
+     * @param kajuu 加重対空値
+     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @return value 割合撃墜数
+     */
+    public double getProportionalShootDownCombined(int kajuu, int combinedKind) {
+        return (kajuu * this.getCombinedBonus(combinedKind)) / 400.0;
+    }
+
+    /**
+     * 割合撃墜数を返します。(通常艦隊専用)
      *
      * @param kajuu 加重対空値
      * @return value 割合撃墜数
      */
     public double getProportionalShootDown(int kajuu) {
-        return kajuu / 400.0;
+        return this.getProportionalShootDownCombined(kajuu, -1);
     }
 
     /**
-     * 固定撃墜数を返します。
-     * 連合艦隊の場合は、shipsに全艦入れる。
+     * 固定撃墜数を返します。(連合艦隊専用)
+     *
+     * @param ship 艦娘
+     * @param allShips 艦隊(第二艦隊も一緒に入れる)
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @param cutinKind 対空カットインの種別
+     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @return value 固定撃墜数
+     */
+    public <SHIP extends ShipBaseDto> int getFixedShootDownCombined(SHIP ship, List<SHIP> allShips,
+            int formation,
+            int cutinKind,
+            int combinedKind) {
+
+        return this.getFixedShootDownCombined(this.getKajuuValue(ship), this.getKantaiValue(allShips, formation),
+                cutinKind,
+                combinedKind);
+    }
+
+    /**
+     * 固定撃墜数を返します。(通常艦隊専用)
      *
      * @param ship 艦娘
      * @param ships 艦隊
@@ -189,13 +230,27 @@ public class CalcTaiku {
      * @return value 固定撃墜数
      */
     public <SHIP extends ShipBaseDto> int getFixedShootDown(SHIP ship, List<SHIP> ships, int formation, int cutinKind) {
-        return (int) ((this.getKajuuValue(ship) + this.getKantaiValue(ships, formation))
-                * this.getTaikuCutinVariableBonus(cutinKind)) / 10;
+        return this.getFixedShootDown(this.getKajuuValue(ship), this.getKantaiValue(ships, formation), cutinKind);
     }
 
     /**
-     * 固定撃墜数を返します。
-     * 連合艦隊の場合は、shipsに全艦入れる。
+     * 固定撃墜数を返します。(連合艦隊専用)
+     *
+     * @param ship 艦娘
+     * @param allShips 艦隊(第二艦隊も一緒に入れる)
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @return value 固定撃墜数
+     */
+    public <SHIP extends ShipBaseDto> int getFixedShootDownCombind(SHIP ship, List<SHIP> allShips,
+            int formation, int combinedKind) {
+
+        return this.getFixedShootDownCombined(this.getKajuuValue(ship), this.getKantaiValue(allShips, formation), -1,
+                combinedKind);
+    }
+
+    /**
+     * 固定撃墜数を返します。(通常艦隊専用)
      *
      * @param ship 艦娘
      * @param ships 艦隊
@@ -203,20 +258,44 @@ public class CalcTaiku {
      * @return value 固定撃墜数
      */
     public <SHIP extends ShipBaseDto> int getFixedShootDown(SHIP ship, List<SHIP> ships, int formation) {
-        return (int) ((this.getKajuuValue(ship) + this.getKantaiValue(ships, formation))
-                * this.getTaikuCutinVariableBonus(0)) / 10;
+        return this.getFixedShootDown(this.getKajuuValue(ship), this.getKantaiValue(ships, formation), -1);
     }
 
     /**
-     * 固定撃墜数を返します。
+     * 固定撃墜数を返します。(連合艦隊専用)
+     *
+     * @param kajuu 加重対空値
+     * @param kantai 艦隊防空値
+     * @param cutinKind 対空カットインの種別
+     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @return value 固定撃墜数
+     */
+    public int getFixedShootDownCombined(int kajuu, double kantai, int cutinKind, int combinedKind) {
+        return (int) ((kajuu + kantai) * this.getCombinedBonus(combinedKind)
+                * this.getTaikuCutinVariableBonus(cutinKind)) / 10;
+    }
+
+    /**
+     * 固定撃墜数を返します。(通常艦隊専用)
      *
      * @param kajuu 加重対空値
      * @param kantai 艦隊防空値
      * @param cutinKind 対空カットインの種別
      * @return value 固定撃墜数
      */
-    public int getFixedShootDown(int kajuu, int kantai, int cutinKind) {
-        return (int) ((kajuu + kantai) * this.getTaikuCutinVariableBonus(cutinKind)) / 10;
+    public int getFixedShootDown(int kajuu, double kantai, int cutinKind) {
+        return this.getFixedShootDownCombined(kajuu, kantai, cutinKind, -1);
+    }
+
+    /**
+     * 固定撃墜数を返します。(通常艦隊専用)
+     *
+     * @param kajuu 加重対空値
+     * @param kantai 艦隊防空値
+     * @return value 固定撃墜数
+     */
+    public int getFixedShootDown(int kajuu, double kantai) {
+        return this.getFixedShootDown(kajuu, kantai, -1);
     }
 
     /**
@@ -236,6 +315,18 @@ public class CalcTaiku {
      */
     public int getSecurity() {
         return 1;
+    }
+
+    // 連合艦隊補正
+    private double getCombinedBonus(int kind) {
+        switch (kind) {
+        case 11: // 水上第一艦隊
+            return 0.8 * 0.9;
+        case 12: // 水上第二艦隊
+            return 0.8 * 0.6;
+        default:
+            return 1.0;
+        }
     }
 
     // 対空カットイン変動ボーナス(七四式準拠)


### PR DESCRIPTION
連合艦隊で水上打撃部隊や空母機動部隊などが分からないと撃墜数が不明な点を見逃していたので、別の値に置き換え