### PR TITLE
いろいろな修正

### DIFF
--- a/main/logbook/constants/AppConstants.java
+++ b/main/logbook/constants/AppConstants.java
@@ -348,7 +348,7 @@ public class AppConstants {
     public static final String MESSAGE_TOTAL_DRAM = "ドラム缶:{0} ({1}隻)。";
 
     /** メッセージ  大発:{0} (+{1}%) */
-    public static final String MESSAGE_TOTAL_DAIHATSU = "大発:{0} (+{1}%)";
+    public static final String MESSAGE_TOTAL_DAIHATSU = "大発:{0} (+{1}%)。";
 
     /** メッセージ  前回の遠征:{0} (+{1}%) */
     public static final String MESSAGE_PREVIOUS_MISSION = "前回の遠征:{0}";

--- a/main/logbook/dto/BattleExDto.java
+++ b/main/logbook/dto/BattleExDto.java
@@ -588,8 +588,8 @@ public class BattleExDto extends AbstractDto {
                         return ResultRank.S;
                     }
                 }
-                // PHASE2:轟沈艦なし かつ 敵艦隊の戦闘開始時の数が1隻以上(必要?) かつ 敵艦の撃沈数が7割以上
-                else if ((friendSunk == 0) && (numStartEships >= 1)
+                // PHASE2:轟沈艦なし かつ 敵艦隊の戦闘開始時の数が1隻より上 かつ 敵艦の撃沈数が7割以上
+                else if ((friendSunk == 0) && (numStartEships > 1)
                         && (enemySunk >= Math.floor(0.7 * numStartEships))) {
                     return ResultRank.A;
                 }

--- a/main/logbook/dto/BattleExDto.java
+++ b/main/logbook/dto/BattleExDto.java
@@ -296,9 +296,12 @@ public class BattleExDto extends AbstractDto {
             this.nowEnemyHpCombined = isEnemyCombined ? beforeEnemyHpCombined.clone() : null;
 
             // 夜間触接
-            JsonValue jsonTouchPlane = object.get("api_touch_plane");
-            if ((jsonTouchPlane != null) && (jsonTouchPlane != JsonValue.NULL)) {
-                this.touchPlane = JsonUtils.getIntArray(object, "api_touch_plane");
+            JsonArray jsonTouchPlane = object.getJsonArray("api_touch_plane");
+            if (jsonTouchPlane != null) {
+                this.touchPlane = new int[] {
+                        Integer.parseInt(jsonTouchPlane.get(0).toString()),
+                        Integer.parseInt(jsonTouchPlane.get(1).toString()),
+                };
             }
 
             // 照明弾発射艦

--- a/main/logbook/dto/BattleExDto.java
+++ b/main/logbook/dto/BattleExDto.java
@@ -183,6 +183,10 @@ public class BattleExDto extends AbstractDto {
     @Tag(51)
     private String resultJson;
 
+    /** 連合艦隊の種類 */
+    @Tag(52)
+    private int combinedKind = 0;
+
     /////////////////////////////////////////////////
 
     /**
@@ -1049,6 +1053,7 @@ public class BattleExDto extends AbstractDto {
                 }
             }
             if (isFriendCombined) {
+                this.combinedKind = GlobalContext.getCombinedKind();
                 numFshipsCombined = 6;
                 for (int i = 1; i <= 6; ++i) {
                     if (maxhpsCombined.getInt(i) == -1) {
@@ -1837,5 +1842,13 @@ public class BattleExDto extends AbstractDto {
      */
     public int getDropShipId() {
         return this.dropShipId;
+    }
+
+    /**
+     * 連合艦隊の種類を取得します
+     * @return 連合艦隊の種類(0:未結成、1:機動部隊、2:水上部隊、3:輸送部隊、-x:強制解隊)
+     */
+    public int getCombinedKind() {
+        return this.combinedKind;
     }
 }

--- a/main/logbook/dto/ShipBaseDto.java
+++ b/main/logbook/dto/ShipBaseDto.java
@@ -293,11 +293,13 @@ public abstract class ShipBaseDto extends AbstractDto {
         for (int i = 0; i < items.size(); i++) {
             ItemInfoDto item = items.get(i);
             if (item != null) {
-                //6:艦上戦闘機,7:艦上爆撃機,8:艦上攻撃機,11:瑞雲系の水上偵察機の場合は制空値を計算する
+                //6:艦上戦闘機,7:艦上爆撃機,8:艦上攻撃機,11:水上爆撃機,45:水上戦闘機,57:噴式戦闘爆撃機の場合は制空値を計算する
                 if ((item.getType2() == 6)
                         || (item.getType2() == 7)
                         || (item.getType2() == 8)
-                        || (item.getType2() == 11)) {
+                        || (item.getType2() == 11)
+                        || (item.getType2() == 45)
+                        || (item.getType2() == 57)) {
                     // スロット数が分からないと計算できない
                     if (this.getOnSlot() == null)
                         return null;

--- a/main/logbook/gui/logic/BattleHtmlGenerator.java
+++ b/main/logbook/gui/logic/BattleHtmlGenerator.java
@@ -128,6 +128,7 @@ public class BattleHtmlGenerator extends HTMLGenerator {
      * @param hp
      * @param phaseName
      */
+    @SuppressWarnings("unchecked")
     private <SHIP extends ShipBaseDto> void genParmeters(String tableTitle,
             List<SHIP> ships, int[][] hp, String[] phaseName, int hqLv, boolean isSecond, String[] formation,
             List<SHIP> allShips, BattleExDto battle) {
@@ -153,7 +154,8 @@ public class BattleHtmlGenerator extends HTMLGenerator {
         this.begin("table", PARAM_TABLE_CLASS[ci]);
         String kantaiValueString;
         if (isFriend) {
-            kantaiValueString = String.format("　(艦隊防空値:%.2f)", calcTaiku.getFriendKantaiValue(allShips, formationNo));
+            kantaiValueString = String.format("　(艦隊防空値:%.2f)",
+                    calcTaiku.getFriendKantaiValue((List<ShipDto>) allShips, formationNo));
         } else {
             kantaiValueString = String.format("　(艦隊防空値:%d)", calcTaiku.getEnemyKantaiValue(allShips, formationNo));
         }
@@ -230,22 +232,24 @@ public class BattleHtmlGenerator extends HTMLGenerator {
             String fixedShootDown = "";
 
             if (isFriend) {
-                this.inline("td", String.format("%d", calcTaiku.getFriendKajuuValue(ship)), null);
+                this.inline("td", String.format("%d", calcTaiku.getFriendKajuuValue((ShipDto) ship)), null);
                 if (battle.isCombined()) {
                     int combinedKind = battle.getCombinedKind();
                     if (combinedKind == 2) { // 水上打撃部隊のみ判明しているため、それ以外は不明にしておく
                         this.inline("td",
-                                String.format("%.2f%%", calcTaiku.getFriendProportionalShootDownCombined(ship,
+                                String.format("%.2f%%", calcTaiku.getFriendProportionalShootDownCombined((ShipDto) ship,
                                         (combinedKind * 10) + (isSecond ? 2 : 1)) * 100),
                                 null);
                         fixedShootDown = String.join("/", airList.stream()
                                 .mapToInt(air -> air.airFire != null ? air.airFire[1] : 0)
-                                .map(kind -> calcTaiku.getFriendFixedShootDownCombined(ship, allShips, formationNo,
+                                .map(kind -> calcTaiku.getFriendFixedShootDownCombined((ShipDto) ship,
+                                        (List<ShipDto>) allShips, formationNo,
                                         kind, (combinedKind * 10) + (isSecond ? 2 : 1)))
                                 .mapToObj(value -> String.valueOf(value))
                                 .toArray(String[]::new));
                         if (fixedShootDown.length() == 0) {
-                            fixedShootDown += calcTaiku.getFriendFixedShootDownCombined(ship, allShips, formationNo, -1,
+                            fixedShootDown += calcTaiku.getFriendFixedShootDownCombined((ShipDto) ship,
+                                    (List<ShipDto>) allShips, formationNo, -1,
                                     (combinedKind * 10) + (isSecond ? 2 : 1));
                         }
                     } else {
@@ -254,15 +258,17 @@ public class BattleHtmlGenerator extends HTMLGenerator {
                     }
                 } else {
                     this.inline("td",
-                            String.format("%.2f%%", calcTaiku.getFriendProportionalShootDown(ship) * 100),
+                            String.format("%.2f%%", calcTaiku.getFriendProportionalShootDown((ShipDto) ship) * 100),
                             null);
                     fixedShootDown = String.join("/", airList.stream()
                             .mapToInt(air -> air.airFire != null ? air.airFire[1] : 0)
-                            .map(kind -> calcTaiku.getFriendFixedShootDown(ship, allShips, formationNo, kind))
+                            .map(kind -> calcTaiku.getFriendFixedShootDown((ShipDto) ship, (List<ShipDto>) allShips,
+                                    formationNo, kind))
                             .mapToObj(value -> String.valueOf(value))
                             .toArray(String[]::new));
                     if (fixedShootDown.length() == 0) {
-                        fixedShootDown += calcTaiku.getFriendFixedShootDown(ship, allShips, formationNo);
+                        fixedShootDown += calcTaiku.getFriendFixedShootDown((ShipDto) ship, (List<ShipDto>) allShips,
+                                formationNo);
                     }
                 }
                 this.inline("td", fixedShootDown, null);

--- a/main/logbook/gui/logic/BattleHtmlGenerator.java
+++ b/main/logbook/gui/logic/BattleHtmlGenerator.java
@@ -233,7 +233,7 @@ public class BattleHtmlGenerator extends HTMLGenerator {
                 this.inline("td", String.format("%d", calcTaiku.getFriendKajuuValue(ship)), null);
                 if (battle.isCombined()) {
                     int combinedKind = battle.getCombinedKind();
-                    if (combinedKind == 1) { // 水上打撃部隊のみ判明しているため、それ以外は不明にしておく
+                    if (combinedKind == 2) { // 水上打撃部隊のみ判明しているため、それ以外は不明にしておく
                         this.inline("td",
                                 String.format("%.2f%%", calcTaiku.getFriendProportionalShootDownCombined(ship,
                                         (combinedKind * 10) + (isSecond ? 2 : 1)) * 100),

--- a/main/logbook/gui/logic/BattleHtmlGenerator.java
+++ b/main/logbook/gui/logic/BattleHtmlGenerator.java
@@ -233,7 +233,7 @@ public class BattleHtmlGenerator extends HTMLGenerator {
                 this.inline("td", String.format("%d", calcTaiku.getFriendKajuuValue(ship)), null);
                 if (battle.isCombined()) {
                     int combinedKind = battle.getCombinedKind();
-                    if (combinedKind > 0) {
+                    if (combinedKind == 1) { // 水上打撃部隊のみ判明しているため、それ以外は不明にしておく
                         this.inline("td",
                                 String.format("%.2f%%", calcTaiku.getFriendProportionalShootDownCombined(ship,
                                         (combinedKind * 10) + (isSecond ? 2 : 1)) * 100),

--- a/main/logbook/gui/logic/BattleHtmlGenerator.java
+++ b/main/logbook/gui/logic/BattleHtmlGenerator.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -131,7 +130,7 @@ public class BattleHtmlGenerator extends HTMLGenerator {
      */
     private <SHIP extends ShipBaseDto> void genParmeters(String tableTitle,
             List<SHIP> ships, int[][] hp, String[] phaseName, int hqLv, boolean isSecond, String[] formation,
-            List<SHIP> allShips) {
+            List<SHIP> allShips, BattleExDto battle) {
         if (ships.size() == 0) {
             return;
         }
@@ -147,10 +146,19 @@ public class BattleHtmlGenerator extends HTMLGenerator {
         }
 
         int numPhases = (hp.length / 2) - 1;
+        CalcTaiku calcTaiku = new CalcTaiku();
+        int formationNo = BattleExDto.fromFormation(formation[isFriend ? 0 : 1]);
 
         this.begin("div", BOX_CLASS);
         this.begin("table", PARAM_TABLE_CLASS[ci]);
-        this.inline("caption", tableTitle, null);
+        String kantaiValueString;
+        if (isFriend) {
+            kantaiValueString = String.format("　(艦隊防空値:%.2f)", calcTaiku.getFriendKantaiValue(allShips, formationNo));
+        } else {
+            kantaiValueString = String.format("　(艦隊防空値:%d)", calcTaiku.getEnemyKantaiValue(allShips, formationNo));
+        }
+        this.inline("caption",
+                tableTitle + kantaiValueString, null);
 
         this.begin("tr", null);
 
@@ -160,7 +168,9 @@ public class BattleHtmlGenerator extends HTMLGenerator {
         this.inline("th", "制空", null);
         this.inline("th", "索敵", null);
         this.inline("th", "加重対空値", null);
-        this.inline("th", "艦隊防空値", null);
+        this.inline("th", "割合撃墜", null);
+        this.inline("th", "固定撃墜", null);
+        this.inline("th", "最低保証数", null);
         this.inline("th", "開始時", null);
         for (int i = 0; i < numPhases; ++i) {
             this.inline("th", "", null);
@@ -184,8 +194,6 @@ public class BattleHtmlGenerator extends HTMLGenerator {
 
         int totalNowHp = 0;
         int totalMaxHp = 0;
-        CalcTaiku calcTaiku = new CalcTaiku();
-        int formationNo = BattleExDto.fromFormation(formation[isFriend ? 0 : 1]);
 
         for (int i = 0; i < ships.size(); ++i) {
             SHIP ship = ships.get(i);
@@ -210,9 +218,81 @@ public class BattleHtmlGenerator extends HTMLGenerator {
 
             this.inline("td", seiku.toString(), null);
             this.inline("td", sakuteki.toString(), null);
-            this.inline("td", String.format("%d", calcTaiku.getKajuuValue(ship)), null);
-            this.inline("td", String.format("+%.2f",
-                    calcTaiku.getKantaiValue(new ArrayList<SHIP>(Arrays.asList(ship)), formationNo)), null);
+
+            // 強引に対空カットインの情報を持ってくる
+            Phase phase = battle.getPhaseList().get(0);
+            List<AirBattleDto> airList = new ArrayList<>();
+            if (phase.getAir() != null)
+                airList.add(phase.getAir());
+            if (phase.getAir2() != null)
+                airList.add(phase.getAir2());
+
+            String fixedShootDown = "";
+
+            if (isFriend) {
+                this.inline("td", String.format("%d", calcTaiku.getFriendKajuuValue(ship)), null);
+                if (battle.isCombined()) {
+                    int combinedKind = battle.getCombinedKind();
+                    if (combinedKind > 0) {
+                        this.inline("td",
+                                String.format("%.2f%%", calcTaiku.getFriendProportionalShootDownCombined(ship,
+                                        (combinedKind * 10) + (isSecond ? 2 : 1)) * 100),
+                                null);
+                        fixedShootDown = String.join("/", airList.stream()
+                                .mapToInt(air -> air.airFire != null ? air.airFire[1] : 0)
+                                .map(kind -> calcTaiku.getFriendFixedShootDownCombined(ship, allShips, formationNo,
+                                        kind, (combinedKind * 10) + (isSecond ? 2 : 1)))
+                                .mapToObj(value -> String.valueOf(value))
+                                .toArray(String[]::new));
+                        if (fixedShootDown.length() == 0) {
+                            fixedShootDown += calcTaiku.getFriendFixedShootDownCombined(ship, allShips, formationNo, -1,
+                                    (combinedKind * 10) + (isSecond ? 2 : 1));
+                        }
+                    } else {
+                        this.inline("td", "不明", null);
+                        fixedShootDown = "不明";
+                    }
+                } else {
+                    this.inline("td",
+                            String.format("%.2f%%", calcTaiku.getFriendProportionalShootDown(ship) * 100),
+                            null);
+                    fixedShootDown = String.join("/", airList.stream()
+                            .mapToInt(air -> air.airFire != null ? air.airFire[1] : 0)
+                            .map(kind -> calcTaiku.getFriendFixedShootDown(ship, allShips, formationNo, kind))
+                            .mapToObj(value -> String.valueOf(value))
+                            .toArray(String[]::new));
+                    if (fixedShootDown.length() == 0) {
+                        fixedShootDown += calcTaiku.getFriendFixedShootDown(ship, allShips, formationNo);
+                    }
+                }
+                this.inline("td", fixedShootDown, null);
+                String security = String.join(" / ", airList.stream()
+                        .mapToInt(air -> air.airFire != null ? air.airFire[1] : 0)
+                        .mapToObj(kind -> String.format("%d (+%d)", calcTaiku.getFriendSecurity(),
+                                calcTaiku.getFriendSecurity(kind) - calcTaiku.getFriendSecurity()))
+                        .toArray(String[]::new));
+                if (security.length() == 0) {
+                    security += String.format("%d (+%d)", calcTaiku.getFriendSecurity(), 0);
+                }
+                this.inline("td", security, null);
+            } else {
+                this.inline("td", String.format("%d", calcTaiku.getEnemyKajuuValue(ship)), null);
+                if (battle.isEnemyCombined()) {
+                    this.inline("td",
+                            String.format("%.2f%%",
+                                    calcTaiku.getEnemyProportionalShootDownCombined(ship, isSecond ? 2 : 1) * 100),
+                            null);
+                    fixedShootDown += calcTaiku.getEnemyFixedShootDownCombined(ship, allShips, formationNo, -1,
+                            isSecond ? 2 : 1);
+                } else {
+                    this.inline("td",
+                            String.format("%.2f%%", calcTaiku.getEnemyProportionalShootDown(ship) * 100), null);
+                    fixedShootDown += calcTaiku.getEnemyFixedShootDown(ship, allShips, formationNo);
+                }
+                this.inline("td", fixedShootDown, null);
+                this.inline("td", String.format("%d (+?)", calcTaiku.getEnemySecurity()), null);
+            }
+
             this.inline("td", nowhp + "/" + maxhp, null);
 
             for (int p = 1; p <= numPhases; ++p) {
@@ -244,14 +324,17 @@ public class BattleHtmlGenerator extends HTMLGenerator {
         this.begin("tr", null);
 
         SeikuString totalSeiku = new SeikuString(ships);
-        SakutekiString totalSakuteki = new SakutekiString(ships, hqLv);
+        SakutekiString totalSakuteki = new SakutekiString(ships,
+                hqLv);
         this.inline("td", "", null);
         this.inline("td", "合計", null);
         this.inline("td", "", null);
         this.inline("td", totalSeiku.toString(), null);
         this.inline("td", totalSakuteki.toString(), null);
         this.inline("td", "", null);
-        this.inline("td", String.format("%.2f", calcTaiku.getKantaiValue(allShips, formationNo)), null);
+        this.inline("td", "", null);
+        this.inline("td", "", null);
+        this.inline("td", "", null);
         this.inline("td", totalNowHp + "/" + totalMaxHp, null);
 
         for (int i = 0; i < numPhases; ++i) {
@@ -259,7 +342,9 @@ public class BattleHtmlGenerator extends HTMLGenerator {
             this.inline("td", getColSpan(3), phaseName[i], null);
         }
 
-        this.inline("td", getColSpan(10), "", null);
+        this.inline("td",
+
+                getColSpan(10), "", null);
 
         this.end(); // tr
 
@@ -1040,11 +1125,11 @@ public class BattleHtmlGenerator extends HTMLGenerator {
         }
         this.genParmeters(battle.getDock().getName(),
                 battle.getDock().getShips(), hpList[0], phaseName, battle.getHqLv(), false, battle.getFormation(),
-                allFriendShips);
+                allFriendShips, battle);
         if (battle.isCombined()) {
             this.genParmeters(battle.getDockCombined().getName(),
                     battle.getDockCombined().getShips(), hpList[1], phaseName, battle.getHqLv(), true,
-                    battle.getFormation(), allFriendShips);
+                    battle.getFormation(), allFriendShips, battle);
         }
         List<EnemyShipDto> allEnemyShips = new ArrayList<EnemyShipDto>();
         allEnemyShips.addAll(battle.getEnemy());
@@ -1052,10 +1137,11 @@ public class BattleHtmlGenerator extends HTMLGenerator {
             allEnemyShips.addAll(battle.getEnemyCombined());
         }
         this.genParmeters(battle.getEnemyName(), battle.getEnemy(), hpList[2], phaseName, 0, false,
-                battle.getFormation(), allEnemyShips);
+                battle.getFormation(), allEnemyShips, battle);
         if (battle.isEnemyCombined()) {
             this.genParmeters("敵護衛部隊",
-                    battle.getEnemyCombined(), hpList[3], phaseName, 0, true, battle.getFormation(), allEnemyShips);
+                    battle.getEnemyCombined(), hpList[3], phaseName, 0, true, battle.getFormation(), allEnemyShips,
+                    battle);
         }
 
         // 装備を生成 //

--- a/main/logbook/gui/logic/CalcTaiku.java
+++ b/main/logbook/gui/logic/CalcTaiku.java
@@ -3,6 +3,7 @@
  */
 package logbook.gui.logic;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import logbook.dto.ItemDto;
@@ -13,15 +14,15 @@ import logbook.dto.ShipParameters;
  * @author Nishisonic
  *
  */
-public class CalcTaiku {
+public final class CalcTaiku {
 
     /**
-     * 加重対空値を返します。
+     * 艦娘の加重対空値を返します。
      *
      * @param ship 艦娘
      * @return kajuu 加重対空値
      */
-    public <SHIP extends ShipBaseDto> int getKajuuValue(SHIP ship) {
+    public <SHIP extends ShipBaseDto> int getFriendKajuuValue(SHIP ship) {
         // 装備
         List<ItemDto> items = ship.getItem2();
 
@@ -35,23 +36,55 @@ public class CalcTaiku {
         int modifier = items.stream().allMatch(item -> item == null) ? 1 : 2;
 
         // X
-        double x = taiku + items.stream().filter(item -> item != null)
-                .mapToDouble(item -> {
+        BigDecimal x = items.stream().filter(item -> item != null)
+                .map(item -> {
                     // 種別
                     int type3 = item.getType3();
                     // 装備倍率
-                    int magnification = this.getKajuuItemMagnification(type3);
+                    BigDecimal magnification = new BigDecimal(this.getKajuuItemMagnification(type3));
                     // 装備対空値
-                    int taik = item.getParam().getTaiku();
+                    BigDecimal taik = new BigDecimal(item.getParam().getTaiku());
                     // 改修係数
-                    int factor = this.getKajuuKaishuFactor(type3);
+                    BigDecimal factor = new BigDecimal(this.getKajuuKaishuFactor(type3));
                     // 装備改修値
                     int level = item.getLevel();
 
-                    return (magnification * taik) + (factor * Math.sqrt(level));
-                }).sum();
+                    return magnification.multiply(taik).add(factor.multiply(new BigDecimal(Math.sqrt(level))));
+                }).reduce(BigDecimal.ZERO, BigDecimal::add).add(new BigDecimal(taiku));
 
-        return (int) (modifier * Math.floor(x / modifier));
+        return (int) (modifier * Math.floor(x.doubleValue() / modifier));
+    }
+
+    /**
+     * 深海棲艦の加重対空値を返します。
+     *
+     * @param ship 深海棲艦
+     * @return kajuu 加重対空値
+     */
+    public <SHIP extends ShipBaseDto> int getEnemyKajuuValue(SHIP ship) {
+        // 装備
+        List<ItemDto> items = ship.getItem2();
+
+        // 深海棲艦の素の対空値
+        int taiku = ship.getTaiku() - items.stream().filter(item -> item != null)
+                .map(ItemDto::getParam)
+                .mapToInt(ShipParameters::getTaiku)
+                .sum();
+
+        // X
+        BigDecimal itemTotal = items.stream().filter(item -> item != null)
+                .map(item -> {
+                    // 種別
+                    int type3 = item.getType3();
+                    // 装備倍率
+                    BigDecimal magnification = new BigDecimal(this.getKajuuItemMagnification(type3));
+                    // 装備対空値
+                    BigDecimal taik = new BigDecimal(item.getParam().getTaiku());
+
+                    return magnification.multiply(taik);
+                }).reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return (int) (Math.floor(2 * Math.floor(Math.sqrt(taiku))) + itemTotal.doubleValue());
     }
 
     // 装備倍率(加重対空)
@@ -82,38 +115,67 @@ public class CalcTaiku {
     }
 
     /**
-     * 艦隊防空値を返します。
+     * 艦娘の艦隊防空値を返します。
      * 連合艦隊の場合は、shipsに全艦入れる。
      *
      * @param ships 艦隊
      * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
-     * @return kajuu 加重対空値
+     * @return kantai 艦隊防空値
      */
-    public <SHIP extends ShipBaseDto> double getKantaiValue(List<SHIP> ships, int formation) {
+    public <SHIP extends ShipBaseDto> double getFriendKantaiValue(List<SHIP> ships, int formation) {
         int kantaiBonus = ships.stream().mapToInt(ship -> {
             List<ItemDto> items = ship.getItem2();
 
             // 各艦の艦隊対空ボーナス値
             int shipBonus = items.stream().filter(item -> item != null)
-                    .mapToInt(item -> {
+                    .map(item -> {
                         // 種別
                         int type3 = item.getType3();
                         // 装備倍率
-                        double magnification = this.getKantaiItemMagnification(type3);
+                        BigDecimal magnification = new BigDecimal(this.getKantaiItemMagnification(type3));
                         // 装備対空値
-                        int taik = item.getParam().getTaiku();
+                        BigDecimal taik = new BigDecimal(item.getParam().getTaiku());
                         // 改修係数
-                        double factor = this.getKantaiKaishuFactor(type3);
+                        BigDecimal factor = new BigDecimal(this.getKantaiKaishuFactor(type3));
                         // 装備改修値
                         int level = item.getLevel();
 
-                        // 浮動小数点の合算で誤差が生じるため、100倍してから100で割る
-                        return (int) (((magnification * taik) + (factor * Math.sqrt(level))) * 100);
-                    }).sum() / 100;
+                        return magnification.multiply(taik)
+                                .add(factor.multiply(new BigDecimal(Math.sqrt(level))));
+                    }).reduce(BigDecimal.ZERO, BigDecimal::add).intValue();
             return shipBonus;
         }).sum();
 
-        return (Math.floor(this.getFormationBonus(formation) * kantaiBonus) * 2) / 1.3;
+        return Math.floor(this.getFormationBonus(formation) * kantaiBonus) * (2 / 1.3);
+    }
+
+    /**
+     * 深海棲艦の艦隊防空値を返します。
+     * 連合艦隊の場合は、shipsに全艦入れる。
+     *
+     * @param ships 艦隊
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @return kantai 艦隊防空値
+     */
+    public <SHIP extends ShipBaseDto> int getEnemyKantaiValue(List<SHIP> ships, int formation) {
+        int kantaiBonus = ships.stream().mapToInt(ship -> {
+            List<ItemDto> items = ship.getItem2();
+
+            int shipBonus = items.stream().filter(item -> item != null)
+                    .map(item -> {
+                        // 種別
+                        int type3 = item.getType3();
+                        // 装備倍率
+                        BigDecimal magnification = new BigDecimal(this.getKantaiItemMagnification(type3));
+                        // 装備対空値
+                        BigDecimal taik = new BigDecimal(item.getParam().getTaiku());
+
+                        return magnification.multiply(taik);
+                    }).reduce(BigDecimal.ZERO, BigDecimal::add).intValue();
+            return shipBonus;
+        }).sum();
+
+        return (int) (Math.floor(this.getFormationBonus(formation) * kantaiBonus) * 2);
     }
 
     // 装備倍率(艦隊防空)
@@ -160,170 +222,332 @@ public class CalcTaiku {
     }
 
     /**
-     * 割合撃墜数を返します。(連合艦隊専用)
+     * 艦娘の割合撃墜数を返します。(連合艦隊専用)
      *
      * @param ship 艦娘
-     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
      * @return value 割合撃墜数
      */
-    public <SHIP extends ShipBaseDto> double getProportionalShootDownCombined(SHIP ship, int combinedKind) {
-        return this.getProportionalShootDownCombined(this.getKajuuValue(ship), combinedKind);
+    public <SHIP extends ShipBaseDto> double getFriendProportionalShootDownCombined(SHIP ship,
+            int combinedKind) {
+        return this.getFriendProportionalShootDownCombined(this.getFriendKajuuValue(ship), combinedKind);
     }
 
     /**
-     * 割合撃墜数を返します。(通常艦隊専用)
+     * 深海棲艦の割合撃墜数を返します。(連合艦隊専用)
+     *
+     * @param ship 深海棲艦
+     * @param combinedKind 種類(第1艦隊ならば1、第2艦隊ならば2)
+     * @return value 割合撃墜数
+     */
+    public <SHIP extends ShipBaseDto> double getEnemyProportionalShootDownCombined(SHIP ship, int combinedKind) {
+        return this.getEnemyProportionalShootDownCombined(this.getEnemyKajuuValue(ship), combinedKind);
+    }
+
+    /**
+     * 艦娘の割合撃墜数を返します。(通常艦隊専用)
      *
      * @param ship 艦娘
      * @return value 割合撃墜数
      */
-    public <SHIP extends ShipBaseDto> double getProportionalShootDown(SHIP ship) {
-        return this.getProportionalShootDown(this.getKajuuValue(ship));
+    public <SHIP extends ShipBaseDto> double getFriendProportionalShootDown(SHIP ship) {
+        return this.getFriendProportionalShootDown(this.getFriendKajuuValue(ship));
     }
 
     /**
-     * 割合撃墜数を返します。(連合艦隊専用)
+     * 深海棲艦の割合撃墜数を返します。(通常艦隊専用)
      *
-     * @param kajuu 加重対空値
-     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @param ship 深海棲艦
      * @return value 割合撃墜数
      */
-    public double getProportionalShootDownCombined(int kajuu, int combinedKind) {
-        return (kajuu * this.getCombinedBonus(combinedKind)) / 400.0;
+    public <SHIP extends ShipBaseDto> double getEnemyProportionalShootDown(SHIP ship) {
+        return this.getEnemyProportionalShootDown(this.getEnemyKajuuValue(ship));
     }
 
     /**
-     * 割合撃墜数を返します。(通常艦隊専用)
+     * 艦娘の割合撃墜数を返します。(連合艦隊専用)
+     *
+     * @param kajuu 加重対空値
+     * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
+     * @return value 割合撃墜数
+     */
+    public double getFriendProportionalShootDownCombined(int kajuu, int combinedKind) {
+        return (kajuu * this.getFriendCombinedBonus(combinedKind)) / 400.0;
+    }
+
+    /**
+     * 深海棲艦の割合撃墜数を返します。(連合艦隊専用)
+     *
+     * @param kajuu 加重対空値
+     * @param combinedKind 種類(第1艦隊ならば1、第2艦隊ならば2)
+     * @return value 割合撃墜数
+     */
+    public double getEnemyProportionalShootDownCombined(int kajuu, int combinedKind) {
+        return (kajuu * this.getEnemyCombinedBonus(combinedKind)) / 400.0;
+    }
+
+    /**
+     * 艦娘の割合撃墜数を返します。(通常艦隊専用)
      *
      * @param kajuu 加重対空値
      * @return value 割合撃墜数
      */
-    public double getProportionalShootDown(int kajuu) {
-        return this.getProportionalShootDownCombined(kajuu, -1);
+    public double getFriendProportionalShootDown(int kajuu) {
+        return this.getFriendProportionalShootDownCombined(kajuu, -1);
     }
 
     /**
-     * 固定撃墜数を返します。(連合艦隊専用)
+     * 深海棲艦の割合撃墜数を返します。(通常艦隊専用)
+     *
+     * @param kajuu 加重対空値
+     * @return value 割合撃墜数
+     */
+    public double getEnemyProportionalShootDown(int kajuu) {
+        return this.getEnemyProportionalShootDownCombined(kajuu, -1);
+    }
+
+    /**
+     * 艦娘の固定撃墜数を返します。(連合艦隊専用)
      *
      * @param ship 艦娘
      * @param allShips 艦隊(第二艦隊も一緒に入れる)
      * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
      * @param cutinKind 対空カットインの種別
-     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
      * @return value 固定撃墜数
      */
-    public <SHIP extends ShipBaseDto> int getFixedShootDownCombined(SHIP ship, List<SHIP> allShips,
+    public <SHIP extends ShipBaseDto> int getFriendFixedShootDownCombined(SHIP ship, List<SHIP> allShips,
             int formation,
             int cutinKind,
             int combinedKind) {
 
-        return this.getFixedShootDownCombined(this.getKajuuValue(ship), this.getKantaiValue(allShips, formation),
+        return this.getFriendFixedShootDownCombined(this.getFriendKajuuValue(ship),
+                this.getFriendKantaiValue(allShips, formation),
                 cutinKind,
                 combinedKind);
     }
 
     /**
-     * 固定撃墜数を返します。(通常艦隊専用)
+     * 深海棲艦の固定撃墜数を返します。(連合艦隊専用)
      *
-     * @param ship 艦娘
-     * @param ships 艦隊
-     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
-     * @param cutinKind 対空カットインの種別
-     * @return value 固定撃墜数
-     */
-    public <SHIP extends ShipBaseDto> int getFixedShootDown(SHIP ship, List<SHIP> ships, int formation, int cutinKind) {
-        return this.getFixedShootDown(this.getKajuuValue(ship), this.getKantaiValue(ships, formation), cutinKind);
-    }
-
-    /**
-     * 固定撃墜数を返します。(連合艦隊専用)
-     *
-     * @param ship 艦娘
+     * @param ship 深海棲艦
      * @param allShips 艦隊(第二艦隊も一緒に入れる)
      * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
-     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @param cutinKind 対空カットインの種別
+     * @param combinedKind 種類(第1艦隊ならば1、第2艦隊ならば2)
      * @return value 固定撃墜数
      */
-    public <SHIP extends ShipBaseDto> int getFixedShootDownCombind(SHIP ship, List<SHIP> allShips,
-            int formation, int combinedKind) {
+    public <SHIP extends ShipBaseDto> int getEnemyFixedShootDownCombined(SHIP ship, List<SHIP> allShips,
+            int formation,
+            int cutinKind,
+            int combinedKind) {
 
-        return this.getFixedShootDownCombined(this.getKajuuValue(ship), this.getKantaiValue(allShips, formation), -1,
+        return this.getEnemyFixedShootDownCombined(this.getEnemyKajuuValue(ship),
+                this.getEnemyKantaiValue(allShips, formation),
+                cutinKind,
                 combinedKind);
     }
 
     /**
-     * 固定撃墜数を返します。(通常艦隊専用)
+     * 艦娘の固定撃墜数を返します。(通常艦隊専用)
+     *
+     * @param ship 艦娘
+     * @param ships 艦隊
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @param cutinKind 対空カットインの種別
+     * @return value 固定撃墜数
+     */
+    public <SHIP extends ShipBaseDto> int getFriendFixedShootDown(SHIP ship, List<SHIP> ships, int formation,
+            int cutinKind) {
+        return this.getFriendFixedShootDown(this.getFriendKajuuValue(ship), this.getFriendKantaiValue(ships, formation),
+                cutinKind);
+    }
+
+    /**
+     * 深海棲艦の固定撃墜数を返します。(通常艦隊専用)
+     *
+     * @param ship 深海棲艦
+     * @param ships 艦隊
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @param cutinKind 対空カットインの種別
+     * @return value 固定撃墜数
+     */
+    public <SHIP extends ShipBaseDto> int getEnemyFixedShootDown(SHIP ship, List<SHIP> ships, int formation,
+            int cutinKind) {
+        return this.getEnemyFixedShootDown(this.getEnemyKajuuValue(ship), this.getEnemyKantaiValue(ships, formation),
+                cutinKind);
+    }
+
+    /**
+     * 艦娘の固定撃墜数を返します。(連合艦隊専用)
+     *
+     * @param ship 艦娘
+     * @param allShips 艦隊(第二艦隊も一緒に入れる)
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
+     * @return value 固定撃墜数
+     */
+    public <SHIP extends ShipBaseDto> int getFriendFixedShootDownCombind(SHIP ship, List<SHIP> allShips,
+            int formation, int combinedKind) {
+
+        return this.getFriendFixedShootDownCombined(this.getFriendKajuuValue(ship),
+                this.getFriendKantaiValue(allShips, formation),
+                -1,
+                combinedKind);
+    }
+
+    /**
+     * 深海棲艦の固定撃墜数を返します。(連合艦隊専用)
+     *
+     * @param ship 深海棲艦
+     * @param allShips 艦隊(第二艦隊も一緒に入れる)
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @param combinedKind 種類(第1艦隊ならば1、第2艦隊ならば2)
+     * @return value 固定撃墜数
+     */
+    public <SHIP extends ShipBaseDto> int getEnemyFixedShootDownCombind(SHIP ship, List<SHIP> allShips,
+            int formation, int combinedKind) {
+
+        return this.getEnemyFixedShootDownCombined(this.getEnemyKajuuValue(ship),
+                this.getEnemyKantaiValue(allShips, formation),
+                -1,
+                combinedKind);
+    }
+
+    /**
+     * 艦娘の固定撃墜数を返します。(通常艦隊専用)
      *
      * @param ship 艦娘
      * @param ships 艦隊
      * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
      * @return value 固定撃墜数
      */
-    public <SHIP extends ShipBaseDto> int getFixedShootDown(SHIP ship, List<SHIP> ships, int formation) {
-        return this.getFixedShootDown(this.getKajuuValue(ship), this.getKantaiValue(ships, formation), -1);
+    public <SHIP extends ShipBaseDto> int getFriendFixedShootDown(SHIP ship, List<SHIP> ships, int formation) {
+        return this.getFriendFixedShootDown(this.getFriendKajuuValue(ship), this.getFriendKantaiValue(ships, formation),
+                -1);
     }
 
     /**
-     * 固定撃墜数を返します。(連合艦隊専用)
+     * 深海棲艦の固定撃墜数を返します。(通常艦隊専用)
+     *
+     * @param ship 深海棲艦
+     * @param ships 艦隊
+     * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
+     * @return value 固定撃墜数
+     */
+    public <SHIP extends ShipBaseDto> int getEnemyFixedShootDown(SHIP ship, List<SHIP> ships, int formation) {
+        return this.getEnemyFixedShootDown(this.getEnemyKajuuValue(ship), this.getEnemyKantaiValue(ships, formation),
+                -1);
+    }
+
+    /**
+     * 艦娘の固定撃墜数を返します。(連合艦隊専用)
      *
      * @param kajuu 加重対空値
      * @param kantai 艦隊防空値
      * @param cutinKind 対空カットインの種別
-     * @param combinedKind 連合艦隊の種類(水上:10の位が1、機動:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11
+     * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
      * @return value 固定撃墜数
      */
-    public int getFixedShootDownCombined(int kajuu, double kantai, int cutinKind, int combinedKind) {
-        return (int) ((kajuu + kantai) * this.getCombinedBonus(combinedKind)
+    public int getFriendFixedShootDownCombined(int kajuu, double kantai, int cutinKind, int combinedKind) {
+        return (int) ((kajuu + kantai) * this.getFriendCombinedBonus(combinedKind)
                 * this.getTaikuCutinVariableBonus(cutinKind)) / 10;
     }
 
     /**
-     * 固定撃墜数を返します。(通常艦隊専用)
+     * 深海棲艦の固定撃墜数を返します。(連合艦隊専用)
+     *
+     * @param kajuu 加重対空値
+     * @param kantai 艦隊防空値
+     * @param cutinKind 対空カットインの種別
+     * @param combinedKind 種類(第1艦隊ならば1、第2艦隊ならば2)
+     * @return value 固定撃墜数
+     */
+    public int getEnemyFixedShootDownCombined(int kajuu, double kantai, int cutinKind, int combinedKind) {
+        return (int) (((kajuu + kantai) * this.getEnemyCombinedBonus(combinedKind)
+                * this.getTaikuCutinVariableBonus(cutinKind)) / 10.6);
+    }
+
+    /**
+     * 艦娘の固定撃墜数を返します。(通常艦隊専用)
      *
      * @param kajuu 加重対空値
      * @param kantai 艦隊防空値
      * @param cutinKind 対空カットインの種別
      * @return value 固定撃墜数
      */
-    public int getFixedShootDown(int kajuu, double kantai, int cutinKind) {
-        return this.getFixedShootDownCombined(kajuu, kantai, cutinKind, -1);
+    public int getFriendFixedShootDown(int kajuu, double kantai, int cutinKind) {
+        return this.getFriendFixedShootDownCombined(kajuu, kantai, cutinKind, -1);
     }
 
     /**
-     * 固定撃墜数を返します。(通常艦隊専用)
+     * 深海棲艦の固定撃墜数を返します。(通常艦隊専用)
      *
      * @param kajuu 加重対空値
      * @param kantai 艦隊防空値
+     * @param cutinKind 対空カットインの種別
      * @return value 固定撃墜数
      */
-    public int getFixedShootDown(int kajuu, double kantai) {
-        return this.getFixedShootDown(kajuu, kantai, -1);
+    public int getEnemyFixedShootDown(int kajuu, double kantai, int cutinKind) {
+        return this.getEnemyFixedShootDownCombined(kajuu, kantai, cutinKind, -1);
     }
 
     /**
-     * 最低保証数を返します。
+     * 艦娘の最低保証数を返します。
      *
      * @param cutinKind 対空カットインの種別
      * @return value 最低保証数
      */
-    public int getSecurity(int cutinKind) {
+    public int getFriendSecurity(int cutinKind) {
         return 1 + this.getTaikuCutinFixedBonus(cutinKind);
     }
 
     /**
-     * 最低保証数を返します。
+     * 艦娘の最低保証数を返します。
      *
      * @return value 最低保証数
      */
-    public int getSecurity() {
+    public int getFriendSecurity() {
         return 1;
     }
 
-    // 連合艦隊補正
-    private double getCombinedBonus(int kind) {
+    /**
+     * 深海棲艦の最低保証数を返します。
+     *
+     * @param cutinKind 対空カットインの種別
+     * @return value 最低保証数
+     */
+    public int getEnemySecurity(int cutinKind) {
+        return this.getTaikuCutinFixedBonus(cutinKind);
+    }
+
+    /**
+     * 深海棲艦の最低保証数を返します。
+     *
+     * @return value 最低保証数
+     */
+    public int getEnemySecurity() {
+        return 0;
+    }
+
+    // 連合艦隊補正(艦娘)
+    private double getFriendCombinedBonus(int kind) {
         switch (kind) {
-        case 11: // 水上第一艦隊
+        case 21: // 水上第一艦隊
             return 0.8 * 0.9;
-        case 12: // 水上第二艦隊
+        case 22: // 水上第二艦隊
+            return 0.8 * 0.6;
+        default:
+            return 1.0;
+        }
+    }
+
+    // 連合艦隊補正(深海棲艦)
+    private double getEnemyCombinedBonus(int kind) {
+        switch (kind) {
+        case 1: // 第一艦隊
+            return 0.8 * 1.0;
+        case 2: // 第二艦隊
             return 0.8 * 0.6;
         default:
             return 1.0;
@@ -357,7 +581,7 @@ public class CalcTaiku {
             return 1.5;
         case 12: // 集中機銃/機銃/電探
             return 1.25;
-        case 13: // Unknown
+        case 13: // 高角砲/集中機銃/電探(摩耶改二不可)
             return 1.35;
         case 14: // 高角砲/機銃/電探(五十鈴改二)
             return 1.0;
@@ -405,7 +629,7 @@ public class CalcTaiku {
             return 6;
         case 12: // 集中機銃/機銃/電探
             return 3;
-        case 13: // Unknown
+        case 13: // 高角砲/集中機銃/電探(摩耶改二不可)
             return 4;
         case 14: // 高角砲/機銃/電探(五十鈴改二)
             return 4;

--- a/main/logbook/gui/logic/CalcTaiku.java
+++ b/main/logbook/gui/logic/CalcTaiku.java
@@ -4,10 +4,12 @@
 package logbook.gui.logic;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 import logbook.dto.ItemDto;
 import logbook.dto.ShipBaseDto;
+import logbook.dto.ShipDto;
 import logbook.dto.ShipParameters;
 
 /**
@@ -22,9 +24,11 @@ public final class CalcTaiku {
      * @param ship 艦娘
      * @return kajuu 加重対空値
      */
-    public <SHIP extends ShipBaseDto> int getFriendKajuuValue(SHIP ship) {
+    public int getFriendKajuuValue(ShipDto ship) {
         // 装備
-        List<ItemDto> items = ship.getItem2();
+        List<ItemDto> items = new ArrayList<ItemDto>();
+        items.addAll(ship.getItem2());
+        items.add(ship.getSlotExItem());
 
         // 艦娘の素の対空値
         int taiku = ship.getTaiku() - items.stream().filter(item -> item != null)
@@ -122,9 +126,11 @@ public final class CalcTaiku {
      * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
      * @return kantai 艦隊防空値
      */
-    public <SHIP extends ShipBaseDto> double getFriendKantaiValue(List<SHIP> ships, int formation) {
+    public double getFriendKantaiValue(List<ShipDto> ships, int formation) {
         int kantaiBonus = ships.stream().mapToInt(ship -> {
-            List<ItemDto> items = ship.getItem2();
+            List<ItemDto> items = new ArrayList<ItemDto>();
+            items.addAll(ship.getItem2());
+            items.add(ship.getSlotExItem());
 
             // 各艦の艦隊対空ボーナス値
             int shipBonus = items.stream().filter(item -> item != null)
@@ -228,8 +234,7 @@ public final class CalcTaiku {
      * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
      * @return value 割合撃墜数
      */
-    public <SHIP extends ShipBaseDto> double getFriendProportionalShootDownCombined(SHIP ship,
-            int combinedKind) {
+    public double getFriendProportionalShootDownCombined(ShipDto ship, int combinedKind) {
         return this.getFriendProportionalShootDownCombined(this.getFriendKajuuValue(ship), combinedKind);
     }
 
@@ -250,7 +255,7 @@ public final class CalcTaiku {
      * @param ship 艦娘
      * @return value 割合撃墜数
      */
-    public <SHIP extends ShipBaseDto> double getFriendProportionalShootDown(SHIP ship) {
+    public double getFriendProportionalShootDown(ShipDto ship) {
         return this.getFriendProportionalShootDown(this.getFriendKajuuValue(ship));
     }
 
@@ -316,7 +321,7 @@ public final class CalcTaiku {
      * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
      * @return value 固定撃墜数
      */
-    public <SHIP extends ShipBaseDto> int getFriendFixedShootDownCombined(SHIP ship, List<SHIP> allShips,
+    public int getFriendFixedShootDownCombined(ShipDto ship, List<ShipDto> allShips,
             int formation,
             int cutinKind,
             int combinedKind) {
@@ -357,7 +362,7 @@ public final class CalcTaiku {
      * @param cutinKind 対空カットインの種別
      * @return value 固定撃墜数
      */
-    public <SHIP extends ShipBaseDto> int getFriendFixedShootDown(SHIP ship, List<SHIP> ships, int formation,
+    public int getFriendFixedShootDown(ShipDto ship, List<ShipDto> ships, int formation,
             int cutinKind) {
         return this.getFriendFixedShootDown(this.getFriendKajuuValue(ship), this.getFriendKantaiValue(ships, formation),
                 cutinKind);
@@ -387,7 +392,7 @@ public final class CalcTaiku {
      * @param combinedKind 連合艦隊の種類(機動:10の位が1、水上:10の位が2、輸送:10の位が3。あと、第1艦隊ならば一の位に1、第2なら2。例:水上第1艦隊の場合、11)
      * @return value 固定撃墜数
      */
-    public <SHIP extends ShipBaseDto> int getFriendFixedShootDownCombind(SHIP ship, List<SHIP> allShips,
+    public int getFriendFixedShootDownCombind(ShipDto ship, List<ShipDto> allShips,
             int formation, int combinedKind) {
 
         return this.getFriendFixedShootDownCombined(this.getFriendKajuuValue(ship),
@@ -422,7 +427,7 @@ public final class CalcTaiku {
      * @param formation 陣形(単縦:1,複縦:2,輪形:3,梯形:4,単横:5,第一:11,第二:12,第三:13,第四:14)
      * @return value 固定撃墜数
      */
-    public <SHIP extends ShipBaseDto> int getFriendFixedShootDown(SHIP ship, List<SHIP> ships, int formation) {
+    public int getFriendFixedShootDown(ShipDto ship, List<ShipDto> ships, int formation) {
         return this.getFriendFixedShootDown(this.getFriendKajuuValue(ship), this.getFriendKantaiValue(ships, formation),
                 -1);
     }

--- a/main/logbook/gui/logic/SeikuString.java
+++ b/main/logbook/gui/logic/SeikuString.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package logbook.gui.logic;
 
@@ -17,7 +17,7 @@ public class SeikuString implements Comparable<SeikuString> {
 
     private static int[][] alevelBonusTable = new int[][] {
             { 0, 0, 2, 5, 9, 14, 14, 22 }, // 艦上戦闘機、水上戦闘機
-            { 0, 0, 0, 0, 0, 0, 0, 0 }, // 艦上爆撃機、艦上攻撃機
+            { 0, 0, 0, 0, 0, 0, 0, 0 }, // 艦上爆撃機、艦上攻撃機、噴式戦闘爆撃機
             { 0, 0, 1, 1, 1, 3, 3, 6 }, // 水上爆撃機
     };
 
@@ -62,6 +62,7 @@ public class SeikuString implements Comparable<SeikuString> {
                     break;
                 case 7: // 艦上爆撃機
                 case 8: // 艦上攻撃機
+                case 57: // 噴式戦闘爆撃機
                     type = 1;
                     break;
                 case 11: // 水上爆撃機
@@ -86,7 +87,7 @@ public class SeikuString implements Comparable<SeikuString> {
                     case 0: // 艦上戦闘機 （水上戦闘機は不明だけど一応入れておく）
                         tyku += item.getLevel() * 0.2;
                         break;
-                    case 1: // 爆戦（爆戦でない艦上爆撃機や艦上攻撃機は不明だけど一応入れておく）
+                    case 1: // 爆戦（爆戦でない艦上爆撃機や艦上攻撃機、噴式戦闘爆撃機は不明だけど一応入れておく）
                         tyku += item.getLevel() * 0.25;
                         break;
                     }
@@ -128,8 +129,7 @@ public class SeikuString implements Comparable<SeikuString> {
     private String seikuTotalString() {
         if (this.seikuToalMin == this.seikuTotalMax) {
             return Integer.toString(this.seikuToalMin);
-        }
-        else {
+        } else {
             return String.format("%d-%d", this.seikuToalMin, this.seikuTotalMax);
         }
     }

--- a/main/logbook/gui/logic/SeikuString.java
+++ b/main/logbook/gui/logic/SeikuString.java
@@ -80,32 +80,38 @@ public class SeikuString implements Comparable<SeikuString> {
                         return;
                     }
 
-                    double tyku = item.getParam().getTyku();
+                    // 搭載機数
+                    int onslot = ship.getOnSlot()[i];
 
-                    // 改修効果 艦戦は★×0.2、爆戦は★×0.25
-                    switch (type) {
-                    case 0: // 艦上戦闘機 （水上戦闘機は不明だけど一応入れておく）
-                        tyku += item.getLevel() * 0.2;
-                        break;
-                    case 1: // 爆戦（爆戦でない艦上爆撃機や艦上攻撃機、噴式戦闘爆撃機は不明だけど一応入れておく）
-                        tyku += item.getLevel() * 0.25;
-                        break;
+                    // 搭載機数が0だと制空値はなくなる
+                    if (onslot > 0) {
+                        double tyku = item.getParam().getTyku();
+
+                        // 改修効果 艦戦は★×0.2、爆戦は★×0.25
+                        switch (type) {
+                        case 0: // 艦上戦闘機 （水上戦闘機は不明だけど一応入れておく）
+                            tyku += item.getLevel() * 0.2;
+                            break;
+                        case 1: // 爆戦（爆戦でない艦上爆撃機や艦上攻撃機、噴式戦闘爆撃機は不明だけど一応入れておく）
+                            tyku += item.getLevel() * 0.25;
+                            break;
+                        }
+
+                        double basePart = tyku * Math.sqrt(onslot);
+
+                        double ialvMin = internalAlevelTable[item.getAlv()];
+                        double ialvMax = internalAlevelTable[item.getAlv() + 1] - 1;
+                        double ialvMid = (ialvMin + ialvMax) / 2;
+
+                        double totalMin = basePart + calcBonusSeiku(type, item.getAlv(), ialvMin);
+                        double totalMid = basePart + calcBonusSeiku(type, item.getAlv(), ialvMid);
+                        double totalMax = basePart + calcBonusSeiku(type, item.getAlv(), ialvMax);
+
+                        this.seikuBase += (int) Math.floor(basePart);
+                        this.seikuToalMin += (int) Math.floor(totalMin);
+                        this.seikuToalMid += (int) Math.floor(totalMid);
+                        this.seikuTotalMax += (int) Math.floor(totalMax);
                     }
-
-                    double basePart = tyku * Math.sqrt(ship.getOnSlot()[i]);
-
-                    double ialvMin = internalAlevelTable[item.getAlv()];
-                    double ialvMax = internalAlevelTable[item.getAlv() + 1] - 1;
-                    double ialvMid = (ialvMin + ialvMax) / 2;
-
-                    double totalMin = basePart + calcBonusSeiku(type, item.getAlv(), ialvMin);
-                    double totalMid = basePart + calcBonusSeiku(type, item.getAlv(), ialvMid);
-                    double totalMax = basePart + calcBonusSeiku(type, item.getAlv(), ialvMax);
-
-                    this.seikuBase += (int) Math.floor(basePart);
-                    this.seikuToalMin += (int) Math.floor(totalMin);
-                    this.seikuToalMid += (int) Math.floor(totalMid);
-                    this.seikuTotalMax += (int) Math.floor(totalMax);
                 }
             }
         }

--- a/main/logbook/gui/logic/TPString.java
+++ b/main/logbook/gui/logic/TPString.java
@@ -1,0 +1,144 @@
+/**
+ *
+ */
+package logbook.gui.logic;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import logbook.dto.ItemDto;
+import logbook.dto.ShipDto;
+
+/**
+ * @author Nishisonic
+ *
+ */
+public class TPString implements Comparable<TPString> {
+
+    private final Map<Integer, Integer> totalShipIdCountMap = new HashMap<Integer, Integer>();
+    private final Map<Integer, Integer> totalShipTypeCountMap = new HashMap<Integer, Integer>();
+    private final Map<Integer, Integer> totalItemCountMap = new HashMap<Integer, Integer>();
+    private int TP = 0;
+
+    private static class ShipParam {
+        public Map<Integer, Long> itemCountMap;
+        public int shipId;
+        public int stype;
+
+        ShipParam(ShipDto ship) {
+            List<ItemDto> items = ship.getItem2();
+            items.add(ship.getSlotExItem());
+
+            this.itemCountMap = items.stream().filter(item -> item != null)
+                    .collect(Collectors.groupingBy(ItemDto::getSlotitemId, Collectors.counting()));
+            this.shipId = ship.getShipId();
+            this.stype = ship.getStype();
+        }
+    }
+
+    public TPString(List<ShipDto> ships) {
+        ships.stream().map(ship -> new ShipParam(ship)).forEach(param -> this.add(param));
+        this.calc();
+    }
+
+    public TPString(ShipDto ship) {
+        ShipParam param = new ShipParam(ship);
+        this.add(param);
+        this.calc();
+    }
+
+    private void add(ShipParam ship) {
+        Map<Integer, Long> items = ship.itemCountMap;
+        int shipId = ship.shipId;
+        int stype = ship.stype;
+        items.forEach((id, count) -> this.totalItemCountMap.put(id,
+                (int) (this.totalItemCountMap.getOrDefault(id, 0) + count)));
+        this.totalShipIdCountMap.put(shipId, this.totalShipIdCountMap.getOrDefault(shipId, 0) + 1);
+        this.totalShipTypeCountMap.put(stype, this.totalShipTypeCountMap.getOrDefault(stype, 0) + 1);
+    }
+
+    private void calc() {
+        this.TP += this.totalShipIdCountMap.entrySet().stream()
+                .mapToInt(map -> this.toTPfromShipId(map.getKey()) * map.getValue()).sum();
+        this.TP += this.totalShipTypeCountMap.entrySet().stream()
+                .mapToInt(map -> this.toTPfromShipType(map.getKey()) * map.getValue()).sum();
+        this.TP += this.totalItemCountMap.entrySet().stream()
+                .mapToInt(map -> this.toTPfromItemId(map.getKey()) * map.getValue()).sum();
+    }
+
+    public int getValue() {
+        return this.TP;
+    }
+
+    @Override
+    public String toString() {
+        int S = this.TP;
+        int A = (int) (this.TP * 0.7);
+        return String.format("TP獲得量: S %d / A %d。", S, A);
+    }
+
+    private int toTPfromShipType(int type) {
+        switch (type) {
+        case 14: // 潜水空母
+            return 1;
+        case 2: // 駆逐艦
+            return 5;
+        case 3: // 軽巡洋艦
+            return 2;
+        case 6: // 航空巡洋艦
+            return 4;
+        case 10: // 航空戦艦
+            return 7;
+        case 22: // 補給艦
+            return 15;
+        case 17: // 揚陸艦
+            return 12;
+        case 16: // 水上機母艦
+            return 9;
+        case 20: // 潜水母艦
+            return 7;
+        case 21: // 練習巡洋艦
+            return 6;
+        default:
+            return 0;
+        }
+    }
+
+    private int toTPfromItemId(int id) {
+        switch (id) {
+        case 75: // ドラム缶(輸送用)
+            return 5;
+        case 68: // 大発動艇
+            return 8;
+        case 193: // 特大発動艇
+            return 8;
+        case 166: // 大発動艇(八九式中戦車＆陸戦隊)
+            return 8;
+        case 167: // 特二式内火艇
+            return 2;
+        case 145: // 戦闘糧食
+            return 1;
+        case 150: // 秋刀魚の缶詰
+            return 1;
+        default:
+            return 0;
+        }
+    }
+
+    private int toTPfromShipId(int id) {
+        switch (id) {
+        case 487: // 鬼怒改二
+            return 8;
+        default:
+            return 0;
+        }
+    }
+
+    @Override
+    public int compareTo(TPString tp) {
+        // TODO 自動生成されたメソッド・スタブ
+        return Integer.compare(this.getValue(), tp.getValue());
+    }
+}

--- a/main/logbook/gui/widgets/FleetComposite.java
+++ b/main/logbook/gui/widgets/FleetComposite.java
@@ -10,6 +10,19 @@ import java.util.Map;
 
 import javax.annotation.CheckForNull;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.wb.swt.SWTResourceManager;
+
 import logbook.config.AppConfig;
 import logbook.constants.AppConstants;
 import logbook.data.context.GlobalContext;
@@ -24,6 +37,7 @@ import logbook.gui.logic.DaihatsuString;
 import logbook.gui.logic.DamageRate;
 import logbook.gui.logic.SakutekiString;
 import logbook.gui.logic.SeikuString;
+import logbook.gui.logic.TPString;
 import logbook.gui.logic.TimeLogic;
 import logbook.gui.logic.TimeString;
 import logbook.internal.AkashiTimer;
@@ -33,19 +47,6 @@ import logbook.internal.LoggerHolder;
 import logbook.internal.SeaExp;
 import logbook.util.CalcExpUtils;
 import logbook.util.SwtUtils;
-
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.StyleRange;
-import org.eclipse.swt.custom.StyledText;
-import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.wb.swt.SWTResourceManager;
 
 /**
  * 艦隊タブのウィジェットです
@@ -366,8 +367,7 @@ public class FleetComposite extends Composite {
                 this.hpmsgLabels[i].setText("退避");
                 this.hpmsgLabels[i].setBackground(ColorManager.getColor(AppConstants.ESCAPED_SHIP_COLOR));
                 this.hpmsgLabels[i].setForeground(null);
-            }
-            else {
+            } else {
                 DamageRate rate = DamageRate.fromHP(nowhp, maxhp);
                 this.hpmsgLabels[i].setText(rate.toString());
                 this.hpmsgLabels[i].setBackground(rate.getBackground());
@@ -383,8 +383,7 @@ public class FleetComposite extends Composite {
                     if (isSortie) {
                         badlyDamaged.add(ship);
                     }
-                }
-                else if (rate == DamageRate.TYUHA) {
+                } else if (rate == DamageRate.TYUHA) {
                     if (AppConfig.get().isWarnByHalfDamage()) {
                         // 中破で警告アイコン
                         this.state.set(WARN);
@@ -496,8 +495,7 @@ public class FleetComposite extends Composite {
             if (isRepairing && AppConfig.get().isShowAkashiTimer()) {
                 // 泊地修理中
                 updator = new AkashiTimerUpdator(timeLabel, dockIndex, i);
-            }
-            else if (!isSortie && (condClearDate != null) && AppConfig.get().isShowCondTimer()) {
+            } else if (!isSortie && (condClearDate != null) && AppConfig.get().isShowCondTimer()) {
                 updator = new Runnable() {
                     @Override
                     public void run() {
@@ -508,8 +506,7 @@ public class FleetComposite extends Composite {
                         if (reststr != null) {
                             str = "疲労あと" + reststr;
                             tip = format.format(condClearDate);
-                        }
-                        else {
+                        } else {
                             str = "疲労まもなく回復";
                         }
                         timeLabel.setText(str);
@@ -522,8 +519,7 @@ public class FleetComposite extends Composite {
             if (updator != null) {
                 updator.run();
                 this.updators.add(updator);
-            }
-            else {
+            } else {
                 timeLabel.setText("");
                 timeLabel.setForeground(null);
                 timeLabel.setToolTipText(null);
@@ -629,48 +625,40 @@ public class FleetComposite extends Composite {
         if ((currentMission != null) && (currentMission.getMission() != null)) {
             // 遠征中
             this.addStyledText(this.message, AppConstants.MESSAGE_MISSION, messageStyle);
-        }
-        else if (GlobalContext.isSortie(this.dock.getId())) {
+        } else if (GlobalContext.isSortie(this.dock.getId())) {
             // 出撃中
             this.addStyledText(this.message, AppConstants.MESSAGE_SORTIE, messageStyle);
             if (this.badlyDamage) {
                 // 大破
                 this.addStyledText(this.message, AppConstants.MESSAGE_STOP_SORTIE, taihaStyle);
-            }
-            else if (combinedFleetBadlyDamaed) {
+            } else if (combinedFleetBadlyDamaed) {
                 // 連合艦隊の他の艦隊に大破艦がある
                 this.addStyledText(this.message, AppConstants.MESSAGE_IN_COMBINED + AppConstants.MESSAGE_STOP_SORTIE,
                         taihaStyle);
-            }
-            else {
+            } else {
                 // 進撃可能
                 this.addStyledText(this.message, AppConstants.MESSAGE_GO_NEXT, messageStyle);
             }
-        }
-        else if (this.badlyDamage) {
+        } else if (this.badlyDamage) {
             // 大破
             this.addStyledText(this.message,
                     MessageFormat.format(AppConstants.MESSAGE_BAD, AppConstants.MESSAGE_BADLY_DAMAGE), taihaStyle);
-        }
-        else if (combinedFleetBadlyDamaed) {
+        } else if (combinedFleetBadlyDamaed) {
             // 連合艦隊の他の艦隊に大破艦がある
             this.addStyledText(this.message, AppConstants.MESSAGE_IN_COMBINED +
                     MessageFormat.format(AppConstants.MESSAGE_BAD, AppConstants.MESSAGE_BADLY_DAMAGE), taihaStyle);
-        }
-        else {
+        } else {
             if (isBathwater) {
                 // 入渠中
                 this.addStyledText(this.message,
                         MessageFormat.format(AppConstants.MESSAGE_BAD, AppConstants.MESSAGE_BATHWATER), messageStyle);
-            }
-            else if (flagshipNeedSupply) {
+            } else if (flagshipNeedSupply) {
                 // 未補給
                 this.addStyledText(this.message, "未補給です。", messageStyle);
                 if (reqSupply) { // 空
                     this.addStyledText(this.message, "出撃できません。", messageStyle);
                 }
-            }
-            else {
+            } else {
                 if (repairState.isRepairing()) {
                     // 泊地修理中
                     this.addStyledText(this.message, "泊地修理中。", messageStyle);
@@ -690,7 +678,8 @@ public class FleetComposite extends Composite {
         this.addStyledText(this.message, "\n", null);
         // 制空
         SeikuString seikuString = new SeikuString(ships);
-        this.addStyledText(this.message, MessageFormat.format(AppConstants.MESSAGE_SEIKU, seikuString.toString()), null);
+        this.addStyledText(this.message, MessageFormat.format(AppConstants.MESSAGE_SEIKU, seikuString.toString()),
+                null);
         if (lostPlanes > 0) {
             this.addStyledText(this.message,
                     MessageFormat.format("損失機:{0}(ボーキ:{1})", lostPlanes, lostPlanes * 5), null);
@@ -713,8 +702,13 @@ public class FleetComposite extends Composite {
             // 大発合計数
             this.addStyledText(this.message, daihatsu.toString(), null);
         }
+
+        // TP獲得量
+        this.addStyledText(this.message, new TPString(ships).toString(), null);
+
         this.addStyledText(this.message, "\n", null);
-        if ((currentMission != null) && (currentMission.getMission() == null) && (previousMission.getMission() != null)) {
+        if ((currentMission != null) && (currentMission.getMission() == null)
+                && (previousMission.getMission() != null)) {
             // 前回の遠征
             String text = previousMission.getDisplayText("missioncheck_" + dock.getId() + "p");
             this.addStyledText(this.message,
@@ -816,7 +810,7 @@ public class FleetComposite extends Composite {
 
     /**
      * 複数の色の中間色を取得する
-     * 
+     *
      * @param raito 割合
      * @param rgbs 色たち
      * @return 色
@@ -843,7 +837,7 @@ public class FleetComposite extends Composite {
 
     /**
      * 2つの色の中間色を取得する
-     * 
+     *
      * @param raito 割合
      * @param start 開始色
      * @param end 終了色
@@ -906,16 +900,14 @@ public class FleetComposite extends Composite {
                         }
                         if (showRemain) {
                             str = "修理あと" + reststr;
-                        }
-                        else {
+                        } else {
                             str = "次回復まで" + nextstr;
                         }
                         tip = "現在までに+" + state.getCurrentGain() + "回復\n" +
                                 "次の回復まで" + nextstr + "\n" +
                                 "全回復まで" + reststr +
                                 "(" + format.format(state.getFinish()) + ")";
-                    }
-                    else {
+                    } else {
                         str = "修理まもなく完了";
                     }
                 }


### PR DESCRIPTION
- 敵の撃墜処理ミス修正
- 艦隊防空値の表示位置変更
- 割合撃墜、固定撃墜、最低保証数再追加
  - これに合わせて、GlobalContextに連合艦隊の状態を取得するメソッド追加
    - BattleExDtoから連合艦隊の状態取得に使用します
- TP獲得量追加
- 噴式戦闘爆撃機の制空値反映
- 勝利判定バグ修正

[追記1] 艦娘側の処理は合っていたんですが、敵側の処理は違う点を見逃していました…すいません
[追記2] A勝利の判定に不備がありました(コメント197の修正)
>197. 名無し 2016年12月17日 17:22
>2.3.0での戦況について、敵が単艦で昼戦で撃沈状態にならない場合に勝利Aが表示されることがあります。
>実際の勝敗判定は損害比率により戦術的勝利Bか戦術的敗北Cでした