### PR TITLE
Linux OSのgtk3 packageが存在した場合の対応

### DIFF
--- a/main/logbook/data/context/GlobalContext.java
+++ b/main/logbook/data/context/GlobalContext.java
@@ -201,6 +201,22 @@ public final class GlobalContext {
         INIT_COMPLETE = true;
     }
 
+    // Linux において gtk3 packageの有無により動作を変えるための設定。
+    // OSの環境変数 GTK3PKG は logbook.sh 起動前に手動で設定しておくこと。
+    // gtk3 packageが存在する場合の設定例. # export GTK3PKG=true
+    public static final boolean GTK3;
+    static {
+        String VAR_NAME = System.getenv("GTK3PKG");
+        if (VAR_NAME.equals("true"))
+        {
+            GTK3 = true;
+        }
+        else
+        {
+            GTK3 = false;
+        }
+    }
+
     private static enum MATERIAL_DIFF {
         NEW_VALUE, OBTAINED, CONSUMED, NONE;
     }

--- a/main/logbook/gui/CalcExpDialog.java
+++ b/main/logbook/gui/CalcExpDialog.java
@@ -131,7 +131,15 @@ public final class CalcExpDialog extends WindowBase {
         label1.setText("今のレベル");
         this.beforelv = new Spinner(plan, SWT.BORDER);
         GridData gdBeforelv = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdBeforelv.widthHint = SwtUtils.DPIAwareWidth(45);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdBeforelv.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdBeforelv.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdBeforelv.widthHint = SwtUtils.DPIAwareWidth(45);
+        }
         this.beforelv.setLayoutData(gdBeforelv);
         this.beforelv.setMaximum(ExpTable.MAX_LEVEL);
         this.beforelv.setMinimum(1);
@@ -149,7 +157,15 @@ public final class CalcExpDialog extends WindowBase {
         label4.setText("目標レベル");
         this.afterlv = new Spinner(plan, SWT.BORDER);
         GridData gdAfterlv = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdAfterlv.widthHint = SwtUtils.DPIAwareWidth(45);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdAfterlv.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdAfterlv.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdAfterlv.widthHint = SwtUtils.DPIAwareWidth(45);
+        }
         this.afterlv.setLayoutData(gdAfterlv);
         this.afterlv.setMaximum(ExpTable.MAX_LEVEL);
         this.afterlv.setMinimum(1);

--- a/main/logbook/gui/CalcPracticeExpDialog.java
+++ b/main/logbook/gui/CalcPracticeExpDialog.java
@@ -101,7 +101,15 @@ public final class CalcPracticeExpDialog extends WindowBase {
         this.shipNameLabels[0].setLayoutData(gdFirstShipName);
         this.firstShipLevel = new Spinner(practiceinfo, SWT.BORDER);
         GridData gdFirstShipLevel = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdFirstShipLevel.widthHint = SwtUtils.DPIAwareWidth(45);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdFirstShipLevel.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdFirstShipLevel.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdFirstShipLevel.widthHint = SwtUtils.DPIAwareWidth(45);
+        }
         this.firstShipLevel.setLayoutData(gdFirstShipLevel);
         this.firstShipLevel.setMaximum(ExpTable.MAX_LEVEL);
         this.firstShipLevel.setMinimum(1);
@@ -115,7 +123,15 @@ public final class CalcPracticeExpDialog extends WindowBase {
         this.shipNameLabels[1].setLayoutData(gdSecondShipName);
         this.secondShipLevel = new Spinner(practiceinfo, SWT.BORDER);
         GridData gdsecondShipLevel = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdsecondShipLevel.widthHint = SwtUtils.DPIAwareWidth(45);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdsecondShipLevel.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdsecondShipLevel.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdsecondShipLevel.widthHint = SwtUtils.DPIAwareWidth(45);
+        }
         this.secondShipLevel.setLayoutData(gdsecondShipLevel);
         this.secondShipLevel.setMaximum(ExpTable.MAX_LEVEL);
         this.secondShipLevel.setMinimum(1);

--- a/main/logbook/gui/ConfigDialog.java
+++ b/main/logbook/gui/ConfigDialog.java
@@ -237,7 +237,15 @@ public final class ConfigDialog extends Dialog {
         proxyPortSpinner.setMinimum(1);
         proxyPortSpinner.setSelection(AppConfig.get().getProxyPort());
         GridData gdProxyPortSpinner = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdProxyPortSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdProxyPortSpinner.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdProxyPortSpinner.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdProxyPortSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        }
         proxyPortSpinner.setLayoutData(gdProxyPortSpinner);
 
         final Button sendDatabaseButton = new Button(compositeConnection, SWT.CHECK);
@@ -380,7 +388,15 @@ public final class ConfigDialog extends Dialog {
         materialintervalSpinner.setMinimum(10);
         materialintervalSpinner.setSelection(AppConfig.get().getMaterialLogInterval());
         GridData gdMaterialIntervalSpinner = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdMaterialIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdMaterialIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdMaterialIntervalSpinner.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdMaterialIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        }
         materialintervalSpinner.setLayoutData(gdMaterialIntervalSpinner);
         new Label(compositeReport, SWT.NONE);
 
@@ -596,7 +612,15 @@ public final class ConfigDialog extends Dialog {
         condSpinner.setMinimum(0);
         condSpinner.setSelection(AppConfig.get().getOkCond());
         GridData gdCondSpinner = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdCondSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdCondSpinner.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdCondSpinner.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdCondSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        }
         condSpinner.setLayoutData(gdCondSpinner);
         new Label(compositeNotify, SWT.NONE);
 
@@ -629,7 +653,16 @@ public final class ConfigDialog extends Dialog {
         intervalSpinner.setMinimum(10);
         intervalSpinner.setSelection(AppConfig.get().getRemindInterbal());
         GridData gdIntervalSpinner = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdIntervalSpinner.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        }
+
         intervalSpinner.setLayoutData(gdIntervalSpinner);
 
         new Label(compositeNotify, SWT.NONE);
@@ -648,7 +681,15 @@ public final class ConfigDialog extends Dialog {
         fullySpinner.setMinimum(0);
         fullySpinner.setSelection(AppConfig.get().getNotifyFully());
         GridData gdFullySpinner = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdFullySpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdFullySpinner.widthHint = SwtUtils.DPIAwareWidth(110);
+            gdFullySpinner.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdFullySpinner.widthHint = SwtUtils.DPIAwareWidth(55);
+        }
         fullySpinner.setLayoutData(gdFullySpinner);
 
         Label fullyLabel2 = new Label(compositeNotify, SWT.NONE);
@@ -792,7 +833,15 @@ public final class ConfigDialog extends Dialog {
         opaqueIntervalSpinner.setMinimum(0);
         opaqueIntervalSpinner.setSelection(AppConfig.get().getOpaqueInterval());
         GridData gdopaqueIntervalSpinner = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdopaqueIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(65);
+        if (logbook.data.context.GlobalContext.GTK3)
+        {
+            gdopaqueIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(130);
+            gdopaqueIntervalSpinner.heightHint = SwtUtils.DPIAwareHeight(36);
+        }
+        else
+        {
+            gdopaqueIntervalSpinner.widthHint = SwtUtils.DPIAwareWidth(65);
+        }
         opaqueIntervalSpinner.setLayoutData(gdopaqueIntervalSpinner);
 
         Label opaqueIntervalSuffix = new Label(opaqueIntervalGroup, SWT.NONE);


### PR DESCRIPTION
障害状況ですが、gtk3 packageが導入されたLinux (ubuntu 16.x、fedora 25にて確認)にて2.3.3のバイナリを使用して、起動直後の設定ウィンドウの"通信"や"通知"の画面上にspinner widgetが正常に表示されません。
ソースのコメントにも記述しましたが、gtk3の導入されたLinux（今やかなりの確率で該当するかと）上で動かす
場合、環境変数 GTK3PKG=true の設定が本変更を有効にする際に必要です。