### PR TITLE
報告書出力時のキャラクタセットをUTF-8に変更、補強増設に装備できるアイテムのタイプに高角砲を追加、その他の修正

### DIFF
--- a/main/logbook/constants/AppConstants.java
+++ b/main/logbook/constants/AppConstants.java
@@ -192,6 +192,9 @@ public class AppConstants {
     /** 文字コード(Shift_JIS) */
     public static final Charset CHARSET = Charset.forName("MS932");
 
+    /** 報告書出力用文字コード(UTF-8) */
+    public static final Charset OUTPUT_REPORT_CHARSET = Charset.forName("UTF-8");
+
     /** アプリケーション設定ファイル  */
     public static final File APP_CONFIG_FILE = new File("./config/internal.xml");
 

--- a/main/logbook/constants/AppConstants.java
+++ b/main/logbook/constants/AppConstants.java
@@ -181,6 +181,7 @@ public class AppConstants {
 
     /** 補強増設に装備できるアイテムのタイプID */
     public static final int[] EXSLOT_ITEM_TYPES = new int[] {
+            4,  // 高角砲
             21, // 機銃
             23, // ダメコン
             27, // バルジ

--- a/main/logbook/dto/BattleExDto.java
+++ b/main/logbook/dto/BattleExDto.java
@@ -830,6 +830,14 @@ public class BattleExDto extends AbstractDto {
         }
 
         /**
+         * 処理対象の艦隊は連合艦隊の第二艦隊か？
+         * @return isFriendSecond
+         */
+        public boolean getisFriendSecond() {
+            return this.isFriendSecond;
+        }
+
+        /**
          * この戦闘フェーズ後の味方艦HP（連合艦隊の時は第一艦隊）
          * @return nowFriendHp
          */

--- a/main/logbook/gui/logic/BattleHtmlGenerator.java
+++ b/main/logbook/gui/logic/BattleHtmlGenerator.java
@@ -930,7 +930,13 @@ public class BattleHtmlGenerator extends HTMLGenerator {
                 int[] flarePos = phase.getFlarePos();
                 if (flarePos != null) {
                     if (flarePos[0] != -1) {
-                        int base = phase.getKind().isHougekiSecond() ? 6 : 0;
+			// int base = phase.getKind().isHougekiSecond() ? 6 : 0;
+			// isHougekiSecond()が通常艦隊編成(自艦隊)の設定値を返してしまうため、
+			// 連合艦隊編成(自艦隊)の場合、正常に動作しない。
+			// 通常艦隊編成(自艦隊)の設定値を返す理由：敵連合艦隊夜戦用のAPI
+			// (COMBINED_EC_BATTLE_MIDNIGHT)が通常艦隊編成(自艦隊)と連合艦隊編成(自艦隊)
+			// で同一のため。
+                        int base = phase.getisFriendSecond() ? 6 : 0;
                         flare[0] = this.getShipName(friendShips, (flarePos[0] - 1) + base);
                     }
                     if (flarePos[1] != -1) {

--- a/main/logbook/gui/logic/CreateReportLogic.java
+++ b/main/logbook/gui/logic/CreateReportLogic.java
@@ -656,11 +656,11 @@ public final class CreateReportLogic {
         OutputStream stream = new BufferedOutputStream(new FileOutputStream(file, applend));
         try {
             if (!file.exists() || (FileUtils.sizeOf(file) <= 0)) {
-                IOUtils.write(StringUtils.join(header, ',') + "\r\n", stream, AppConstants.CHARSET);
+                IOUtils.write(StringUtils.join(header, ',') + "\r\n", stream, AppConstants.OUTPUT_REPORT_CHARSET);
             }
             for (Comparable[] colums : body) {
                 IOUtils.write(StringUtils.join(ReportUtils.toStringArray(colums), ',') + "\r\n", stream,
-                        AppConstants.CHARSET);
+                        AppConstants.OUTPUT_REPORT_CHARSET);
             }
         } finally {
             stream.close();

--- a/main/logbook/gui/logic/TPString.java
+++ b/main/logbook/gui/logic/TPString.java
@@ -117,6 +117,8 @@ public class TPString implements Comparable<TPString> {
             return 8;
         case 166: // 大発動艇(八九式中戦車＆陸戦隊)
             return 8;
+        case 230: // 特大発動艇+戦車第11連隊
+            return 8;
         case 167: // 特二式内火艇
             return 2;
         case 145: // 戦闘糧食


### PR DESCRIPTION
１．現行のキャラクタセット：MS932の場合、所有装備一覧をCSVファイルへ出力した際のごく一部の装備名(例：Laté 298B)と所有艦娘一覧をCSVファイルへ出力した際の鍵カラムのハートマークが文字化けします。この対応のため、報告書出力時のキャラクタセットをUTF-8に変更しました。ただし、この修正の影響によりMS932で問題の発生しないその他の報告書（ドロップ報告書、建造報告書など）のキャラクタセットもUTF-8に変更されます。
２．一部の艦娘に限定されますが、補強増設に装備できるアイテムのタイプに高角砲が追加されたため、その表示が可能となるよう修正しました。
ご検討の程よろしくお願いします。