### PR TITLE
艦隊全体の装備込み対潜値の表示を追加

### DIFF
--- a/main/logbook/constants/AppConstants.java
+++ b/main/logbook/constants/AppConstants.java
@@ -340,6 +340,9 @@ public class AppConstants {
     /** メッセージ 索敵:{0}+{1} */
     public static final String MESSAGE_SAKUTEKI = "索敵:{0}。";
 
+    /** メッセージ 対潜:{0} */
+    public static final String MESSAGE_TAISEN = "対潜:{0}。";
+
     /** メッセージ  艦隊合計Lv:{0} */
     public static final String MESSAGE_TOTAL_LV = "艦隊合計Lv:{0}。";
 

--- a/main/logbook/dto/ShipDto.java
+++ b/main/logbook/dto/ShipDto.java
@@ -103,6 +103,10 @@ public final class ShipDto extends ShipBaseDto implements Comparable<ShipDto> {
 
     @Tag(40)
     private final String json;
+    
+    /** 対潜値 */
+    @Tag(41)
+    private final int taisen;
 
     /**
      * コンストラクター
@@ -143,6 +147,8 @@ public final class ShipDto extends ShipBaseDto implements Comparable<ShipDto> {
         this.slotExItem = GlobalContext.getItem(this.getSlotEx());
 
         this.json = object.toString();
+
+        this.taisen = object.getJsonArray("api_taisen").getJsonNumber(0).intValue();
     }
 
     /** 新規入手艦 */
@@ -184,6 +190,8 @@ public final class ShipDto extends ShipBaseDto implements Comparable<ShipDto> {
         this.slotExItem = null;
 
         this.json = null;
+
+        this.taisen = 0;
     }
 
     /**
@@ -270,6 +278,15 @@ public final class ShipDto extends ShipBaseDto implements Comparable<ShipDto> {
     @Override
     public int getLv() {
         return this.lv;
+    }
+
+    /**
+     * 対潜
+     * @return 対潜
+     */
+    @Override
+    public int getTaisen() {
+        return this.taisen;
     }
 
     /**

--- a/main/logbook/gui/widgets/FleetComposite.java
+++ b/main/logbook/gui/widgets/FleetComposite.java
@@ -297,6 +297,8 @@ public class FleetComposite extends Composite {
         }
         // 艦隊合計Lv
         int totallv = 0;
+        // 艦隊合計対潜値(装備込)
+        int totaltaisen = 0;
 
         int dockIndex = Integer.parseInt(dock.getId()) - 1;
         CondTiming condTiming = GlobalContext.getCondTiming();
@@ -340,6 +342,8 @@ public class FleetComposite extends Composite {
             float fuelraito = fuelmax != 0 ? (float) fuel / (float) fuelmax : 1f;
             // 艦隊合計Lv
             totallv += ship.getLv();
+            // 艦隊合計対潜値(装備込)
+            totaltaisen += ship.getTaisen();
             // 損失艦載機
             int[] maxeq = ship.getMaxeq();
             int[] onslot = ship.getOnSlot();
@@ -727,7 +731,10 @@ public class FleetComposite extends Composite {
         // 索敵
         SakutekiString sakutekiString = new SakutekiString(ships, GlobalContext.hqLevel());
         this.addStyledText(this.message,
-                MessageFormat.format(AppConstants.MESSAGE_SAKUTEKI, sakutekiString.toString()), null);
+                MessageFormat.format(AppConstants.MESSAGE_SAKUTEKI, sakutekiString.toString()), null);        
+        this.addStyledText(this.message, "\n", null);
+        // 合計対潜値(装備込)
+        this.addStyledText(this.message, MessageFormat.format(AppConstants.MESSAGE_TAISEN, totaltaisen), null);
         this.addStyledText(this.message, "\n", null);
         // 合計Lv
         this.addStyledText(this.message, MessageFormat.format(AppConstants.MESSAGE_TOTAL_LV, totallv), null);


### PR DESCRIPTION
2017年10月18日の更新で追加された新しい任務において、艦隊全体の対潜値(装備込)の値により成否が判定されます。このため、艦隊全体の対潜値(装備込)の値の表示を追加しました。
※：索敵値の表示は "素の索敵値"＋"装備の索敵値" このように分かれていますが、今回の対潜値は分けておらず装備込みの値を１つだけ表示しています。