### PR TITLE
新遠征の成否チェックに対応（それに伴い艦隊全体の装備込み対空値の表示を可能にする修正を実施）

### DIFF
--- a/main/logbook/constants/AppConstants.java
+++ b/main/logbook/constants/AppConstants.java
@@ -343,6 +343,9 @@ public class AppConstants {
     /** メッセージ 対潜:{0} */
     public static final String MESSAGE_TAISEN = "対潜:{0}。";
 
+    /** メッセージ 対空:{0} */
+    public static final String MESSAGE_TAIKU = "対空:{0}。";
+
     /** メッセージ  艦隊合計Lv:{0} */
     public static final String MESSAGE_TOTAL_LV = "艦隊合計Lv:{0}。";
 

--- a/main/logbook/gui/widgets/FleetComposite.java
+++ b/main/logbook/gui/widgets/FleetComposite.java
@@ -299,6 +299,8 @@ public class FleetComposite extends Composite {
         int totallv = 0;
         // 艦隊合計対潜値(装備込)
         int totaltaisen = 0;
+        // 艦隊合計対空値(装備込)
+        int totaltaiku = 0;
 
         int dockIndex = Integer.parseInt(dock.getId()) - 1;
         CondTiming condTiming = GlobalContext.getCondTiming();
@@ -344,6 +346,8 @@ public class FleetComposite extends Composite {
             totallv += ship.getLv();
             // 艦隊合計対潜値(装備込)
             totaltaisen += ship.getTaisen();
+            // 艦隊合計対空値(装備込)
+            totaltaiku += ship.getTaiku();
             // 損失艦載機
             int[] maxeq = ship.getMaxeq();
             int[] onslot = ship.getOnSlot();
@@ -735,6 +739,9 @@ public class FleetComposite extends Composite {
         this.addStyledText(this.message, "\n", null);
         // 合計対潜値(装備込)
         this.addStyledText(this.message, MessageFormat.format(AppConstants.MESSAGE_TAISEN, totaltaisen), null);
+        this.addStyledText(this.message, "\n", null);
+        // 合計対空値(装備込)
+        this.addStyledText(this.message, MessageFormat.format(AppConstants.MESSAGE_TAIKU, totaltaiku), null);
         this.addStyledText(this.message, "\n", null);
         // 合計Lv
         this.addStyledText(this.message, MessageFormat.format(AppConstants.MESSAGE_TOTAL_LV, totallv), null);

--- a/script/util_missioncheck.js
+++ b/script/util_missioncheck.js
@@ -15,6 +15,7 @@ function setFleet(fleetid) {
 		sumShipLv: 0,
 		drumShipCount: 0,
 		drumCount: 0,
+		DECount: 0,
 		DDCount: 0,
 		CLCount: 0,
 		CLTCount: 0,
@@ -31,7 +32,12 @@ function setFleet(fleetid) {
 		ASCount: 0,
 		LHACount: 0,
 		ACVCount: 0,
-		ARCount: 0
+		ARCount: 0,
+		sumTaisen: 0,
+		ECCount: 0,
+		sumMinusTaisen: 0,
+		sumTaiku: 0,
+		sumSakuteki: 0
 	};
 	
 	//艦隊データオブジェクト設定
@@ -57,14 +63,53 @@ function setFleet(fleetid) {
 		//艦隊合計Lv
 		currentDockData.sumShipLv += ships[i].lv;
 
+		//艦隊合計対潜
+		currentDockData.sumTaisen += ships[i].getTaisen();
+
+		//対潜値対象外装備の合計
+		// +1 : 九八式水上偵察機(夜偵),OS2U,二式大艇,Ro.44水上戦闘機,二式水戦改,Ro.44水上戦闘機bis,二式水戦改(熟練)
+
+		// +2 : Late 298B,瑞雲(六三一空),Ro.43水偵,零式水上偵察機,紫雲,PBY-5A Catalina
+		// +3 : 晴嵐(六三一空)
+		// +4 : 瑞雲,零式水上観測機
+		// +5 : 瑞雲(六三四空),瑞雲12型,Ar196改
+		// +6 : 瑞雲12型(六三四空),瑞雲(六三四空/熟練),試製晴嵐
+		// +7 : 零式水上偵察機11型乙
+		for(var j = 0; j < ships[i].slot.length; j++){
+
+			if((ships[i].slot[j].match(/^九八式水上偵察機\(夜偵\)$/)) || (ships[i].slot[j].match(/^OS2U$/)) || (ships[i].slot[j].match(/^二式大艇$/)) || (ships[i].slot[j].match(/^Ro.44水上戦闘機$/)) || (ships[i].slot[j].match(/^二式水戦改$/)) || (ships[i].slot[j].match(/^Ro.44水上戦闘機bis$/)) || (ships[i].slot[j].match(/^二式水戦改\(熟練\)$/))) {
+				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 1;
+			} else if ((ships[i].slot[j].match(/^La/)) || (ships[i].slot[j].match(/^瑞雲\(六三一空\)$/)) || (ships[i].slot[j].match(/^Ro.43水偵$/)) || (ships[i].slot[j].match(/^零式水上偵察機$/)) || (ships[i].slot[j].match(/^紫雲$/)) || (ships[i].slot[j].match(/^PBY-5A Catalina$/))){
+				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 2;
+			} else if (ships[i].slot[j].match(/^晴嵐\(六三一空\)$/)) {
+				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 3;
+			} else if ((ships[i].slot[j].match(/^瑞雲$/)) || (ships[i].slot[j].match(/^零式水上観測機$/))) {
+				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 4;
+			} else if ((ships[i].slot[j].match(/^瑞雲\(六三四空\)$/)) || (ships[i].slot[j].match(/^瑞雲12型$/)) || (ships[i].slot[j].match(/^Ar196改$/))) {
+				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 5;
+			} else if ((ships[i].slot[j].match(/^瑞雲12型\(六三四空\)$/)) || (ships[i].slot[j].match(/^瑞雲\(六三四空\/熟練\)$/)) || (ships[i].slot[j].match(/^試製晴嵐$/))) {
+				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 6;
+			} else if (ships[i].slot[j].match(/^零式水上偵察機11型乙$/)) {
+				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 7;
+			} else {
+			}
+
+		}
+
+		//艦隊合計対空
+		currentDockData.sumTaiku += ships[i].getTaiku();
+
+		//艦隊合計索敵
+		currentDockData.sumSakuteki += ships[i].getSakuteki();
+
 		//艦種カウント
 		switch(ships[i].stype){
+			case 1: currentDockData.DECount++; break;
 			case 2: currentDockData.DDCount++; break;
 			case 3: currentDockData.CLCount++; break;
 			case 4: currentDockData.CLTCount++; break;
 			case 5: currentDockData.CACount++; break;
 			case 6: currentDockData.CVACount++; break;
-			case 7: currentDockData.CVLCount++; break;
 			case 8: currentDockData.BBCount++; break;
 			case 9: currentDockData.BBCount++; break;
 			case 10: currentDockData.CVBCount++; break;
@@ -79,6 +124,17 @@ function setFleet(fleetid) {
 			case 20: currentDockData.ASCount++; break;
 			case 21: currentDockData.TVCount++; break;
 		}
+		if ((ships[i].stype == 7) && (!(ships[i].name.match(/大鷹/))))
+		{
+			currentDockData.CVLCount++;
+		}
+		else if ((ships[i].stype == 7) && (ships[i].name.match(/大鷹/)))
+		{
+			currentDockData.ECCount++;
+		}
+		else
+		{
+		}
 	}
 }
 
@@ -88,12 +144,12 @@ function getCanMission(missionID){
 		case 1: return sTypeFree(2, 1);
 		case 2: return sTypeFree(4, 2);
 		case 3: return sTypeFree(3, 3);
-		case 4: return sTypeLock(3, 3, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0);
-		case 5: return sTypeLock(4, 3, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0);
+		case 4: return sTypeLock2(3, 3, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0);
+		case 5: return sTypeLock2(4, 3, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0);
 		case 6: return sTypeFree(4, 4);
 		case 7: return sTypeFree(6, 5);
 		case 8: return sTypeFree(6, 6);
-		case 9: return sTypeLock(4, 3, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0);
+		case 9: return sTypeLock2(4, 3, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0);
 		case 10: return sTypeLock(3, 3, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0);
 		case 11: return sTypeLock(4, 6, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0);
 		case 12: return sTypeLock(4, 4, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0);
@@ -125,6 +181,10 @@ function getCanMission(missionID){
 		case 38: return sTypeLock(6, 65, 240, 0, 4, 8, 0, 5, 0, 0, 0, 0, 0, 0, 0);
 		case 39: return sTypeLock(5, 3, 180, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 1, 0);
 		case 40: return sTypeLock(6, 25, 150, 3, 0, 0, 1, 2, 0, 0, 0, 0, 2, 0, 0); // 水上機前線輸送
+		case 100: return sTypeLock4(4, 5, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0); // 兵站強化任務
+		case 101: return sTypeLock4(4, 20, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 180, 4, 70); // 海峡警備行動
+		case 102: return sTypeLock5(5, 35, 185, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0, 0, 280, 3, 1); // 長時間対潜警戒
+		case 110: return sTypeLock3(6, 40, 150, 0, 0, 0, 1, 2, 0, 0, 0, 0, 1, 0, 0, 200, 0, 200, 140); // 南西方面航空偵察作戦
 		default: return "?";
 	}
 }
@@ -154,6 +214,114 @@ function sTypeLock(shipCount, flgShipLv, sumShipLv, flgType, drumShipCount, drum
 	}
 }
 
+//艦種縛り他諸条件
+//艦数 旗艦Lv 合計Lv 旗艦艦種 ドラム缶艦数 ドラム缶合計数 軽巡 駆逐 空母 航戦 潜水艦 重巡 水母 潜水艦母艦 練習艦
+function sTypeLock2(shipCount, flgShipLv, sumShipLv, flgType, drumShipCount, drumCount, CLCount, DDCount, CVCount, CVBCount, SSCount, CACount, AVCount, ASCount, TVCount){
+	if(currentDockData.shipCount >= shipCount && 
+			currentDockData.flgShipLv >= flgShipLv && 
+			currentDockData.sumShipLv >= sumShipLv &&
+			(flgType == 0 || currentDockData.flgType == flgType) &&
+			currentDockData.drumShipCount >= drumShipCount &&
+			currentDockData.drumCount >= drumCount &&
+			(((currentDockData.CLCount >= CLCount) && (currentDockData.DDCount >= DDCount))  || (currentDockData.DDCount==1 && currentDockData.DECount==3) || (currentDockData.CLCount >= 1 && currentDockData.DECount >= 2) || (currentDockData.TVCount >= 1 && currentDockData.DECount >= 2) || (currentDockData.ECCount >= 1 && currentDockData.DECount >= 2) || (currentDockData.ECCount >= 1 && currentDockData.DDCount >= 2)) && 
+			(currentDockData.CVCount + currentDockData.CVLCount + currentDockData.ACVCount + currentDockData.AVCount) >= CVCount &&
+			currentDockData.CVBCount >= CVBCount &&
+			(currentDockData.SSCount + currentDockData.CVSCount) >= SSCount &&
+			currentDockData.CACount >= CACount &&
+			currentDockData.AVCount >= AVCount &&
+			currentDockData.ASCount >= ASCount &&
+			currentDockData.TVCount >= TVCount
+	){
+		return "○";
+	}else{
+		return "×";
+	}
+}
+
+//艦種縛り他諸条件
+//艦数 旗艦Lv 合計Lv 旗艦艦種 ドラム缶艦数 ドラム缶合計数 軽巡 駆逐 空母 航戦 潜水艦 重巡 水母 潜水艦母艦 練習艦 合計対潜 海防 合計対空 合計索敵
+function sTypeLock3(shipCount, flgShipLv, sumShipLv, flgType, drumShipCount, drumCount, CLCount, DDCount, CVCount, CVBCount, SSCount, CACount, AVCount, ASCount, TVCount, sumTaisen, DECount, sumTaiku, sumSakuteki){
+	if(currentDockData.shipCount >= shipCount && 
+			currentDockData.flgShipLv >= flgShipLv && 
+			currentDockData.sumShipLv >= sumShipLv &&
+			(flgType == 0 || currentDockData.flgType == flgType) &&
+			currentDockData.drumShipCount >= drumShipCount &&
+			currentDockData.drumCount >= drumCount &&
+			currentDockData.CLCount >= CLCount && 
+			(((currentDockData.DDCount + currentDockData.DECount) >= DDCount) || 	((currentDockData.DDCount + currentDockData.DECount) >= DECount)) && 
+			(currentDockData.CVCount + currentDockData.CVLCount + currentDockData.ACVCount + currentDockData.AVCount) >= CVCount &&
+			currentDockData.CVBCount >= CVBCount &&
+			(currentDockData.SSCount + currentDockData.CVSCount) >= SSCount &&
+			currentDockData.CACount >= CACount &&
+			currentDockData.AVCount >= AVCount &&
+			currentDockData.ASCount >= ASCount &&
+			currentDockData.TVCount >= TVCount &&
+			(currentDockData.sumTaisen - currentDockData.sumMinusTaisen) >= sumTaisen &&
+			currentDockData.sumTaiku >= sumTaiku &&
+			currentDockData.sumSakuteki >= sumSakuteki 
+			
+	){
+		return "○";
+	}else{
+		return "×";
+	}
+}
+
+
+//艦種縛り他諸条件
+//艦数 旗艦Lv 合計Lv 旗艦艦種 ドラム缶艦数 ドラム缶合計数 軽巡 駆逐 空母 航戦 潜水艦 重巡 水母 潜水艦母艦 練習艦 合計対潜 海防 合計対空
+function sTypeLock4(shipCount, flgShipLv, sumShipLv, flgType, drumShipCount, drumCount, CLCount, DDCount, CVCount, CVBCount, SSCount, CACount, AVCount, ASCount, TVCount, sumTaisen, DECount, sumTaiku){
+	if(currentDockData.shipCount >= shipCount && 
+			currentDockData.flgShipLv >= flgShipLv && 
+			currentDockData.sumShipLv >= sumShipLv &&
+			(flgType == 0 || currentDockData.flgType == flgType) &&
+			currentDockData.drumShipCount >= drumShipCount &&
+			currentDockData.drumCount >= drumCount &&
+			currentDockData.CLCount >= CLCount && 
+			(((currentDockData.DDCount + currentDockData.DECount) >= DDCount) || 	((currentDockData.DDCount + currentDockData.DECount) >= DECount)) && 
+			(currentDockData.CVCount + currentDockData.CVLCount + currentDockData.ACVCount + currentDockData.AVCount) >= CVCount &&
+			currentDockData.CVBCount >= CVBCount &&
+			(currentDockData.SSCount + currentDockData.CVSCount) >= SSCount &&
+			currentDockData.CACount >= CACount &&
+			currentDockData.AVCount >= AVCount &&
+			currentDockData.ASCount >= ASCount &&
+			currentDockData.TVCount >= TVCount &&
+			currentDockData.sumTaisen >= sumTaisen &&
+			currentDockData.sumTaiku >= sumTaiku
+	){
+		return "○";
+	}else{
+		return "×";
+	}
+}
+
+
+//艦種縛り他諸条件
+//艦数 旗艦Lv 合計Lv 旗艦艦種 ドラム缶艦数 ドラム缶合計数 軽巡 駆逐 空母 航戦 潜水艦 重巡 水母 潜水艦母艦 練習艦 合計対潜 海防 護衛空母
+function sTypeLock5(shipCount, flgShipLv, sumShipLv, flgType, drumShipCount, drumCount, CLCount, DDCount, CVCount, CVBCount, SSCount, CACount, AVCount, ASCount, TVCount, sumTaisen, DECount, CVECount){
+	if(currentDockData.shipCount >= shipCount && 
+			currentDockData.flgShipLv >= flgShipLv && 
+			currentDockData.sumShipLv >= sumShipLv &&
+			(flgType == 0 || currentDockData.flgType == flgType) &&
+			currentDockData.drumShipCount >= drumShipCount &&
+			currentDockData.drumCount >= drumCount &&
+			(   ((currentDockData.CLCount >= CLCount && (currentDockData.DDCount + currentDockData.DECount) >= DDCount) || 	( currentDockData.CLCount >= CLCount && (currentDockData.DDCount + currentDockData.DECount) >= DECount)) || (currentDockData.DDCount >= 1 && currentDockData.DECount >= 3) || (currentDockData.TVCount >= 1 && currentDockData.DECount >= 2) || (currentDockData.ECCount >= 1 && currentDockData.DECount >= 2)  )  && 
+			(currentDockData.CVCount + currentDockData.CVLCount + currentDockData.ACVCount + currentDockData.AVCount) >= CVCount &&
+			currentDockData.CVBCount >= CVBCount &&
+			(currentDockData.SSCount + currentDockData.CVSCount) >= SSCount &&
+			currentDockData.CACount >= CACount &&
+			currentDockData.AVCount >= AVCount &&
+			currentDockData.ASCount >= ASCount &&
+			currentDockData.TVCount >= TVCount &&
+			currentDockData.sumTaisen >= sumTaisen
+			
+	){
+		return "○";
+	}else{
+		return "×";
+	}
+}
+
 //艦種縛り無し
 //必要艦数と旗艦Lv
 function sTypeFree(shipCount, flgShipLv){
@@ -166,6 +334,7 @@ function sTypeFree(shipCount, flgShipLv){
 
 
 //艦種記号
+//	DE	海防
 //	DD	駆逐
 //	CL	軽巡
 //	CLT	雷巡
@@ -174,6 +343,7 @@ function sTypeFree(shipCount, flgShipLv){
 //	BB	戦艦
 //	CV	正規空母
 //	CVL	軽空母
+//	EC	護衛空母
 //	SS	潜水艦
 //	CVS	潜水空母
 //	CVB	航空戦艦


### PR DESCRIPTION
艦隊全体の装備込み対空値の表示を追加 ですが、新遠征で艦隊全体の対空値を評価する必要があるため修正しています。