### PR TITLE
艦娘の複数同時解体および解体時の装備保管の対応、遠征成否チェックスクリプトの不具合の修正

### DIFF
--- a/main/logbook/data/context/GlobalContext.java
+++ b/main/logbook/data/context/GlobalContext.java
@@ -1989,60 +1989,6 @@ public final class GlobalContext {
     }
 
     /**
-     * @param data
-     */
-    private static void doSlotDeprive(Data data, JsonValue json) {
-        try {
-            // 装備中の装備を取り外される艦の処理
-            int unset_shipId = Integer.parseInt(data.getField("api_unset_ship"));
-            ShipDto unset_ship = shipMap.get(unset_shipId);
-            if (unset_ship != null) {
-                if (json instanceof JsonObject) {
-                    JsonObject apidata = (JsonObject) json;
-                    JsonObject shipdata = apidata.getJsonObject("api_ship_data");
-                    JsonObject unsetship = shipdata.getJsonObject("api_unset_ship");
-                    unset_ship.setSlotFromJson(unsetship);
-
-                    // 次アップデート
-                    String unset_fleetid = unset_ship.getFleetid();
-                    if (unset_fleetid != null) {
-                        DockDto unset_dockdto = dock.get(unset_fleetid);
-                        if (unset_dockdto != null) {
-                            unset_dockdto.setUpdate(true);
-                        }
-                    }
-                }
-            }
-
-            // 取り外された装備を装備する艦の処理
-            int set_shipId = Integer.parseInt(data.getField("api_set_ship"));
-            ShipDto set_ship = shipMap.get(set_shipId);
-            if (set_ship != null) {
-                if (json instanceof JsonObject) {
-                    JsonObject apidata = (JsonObject) json;
-                    JsonObject shipdata = apidata.getJsonObject("api_ship_data");
-                    JsonObject setship = shipdata.getJsonObject("api_set_ship");
-                    set_ship.setSlotFromJson(setship);
-
-                    // 次アップデート
-                    String set_fleetid = set_ship.getFleetid();
-                    if (set_fleetid != null) {
-                        DockDto set_dockdto = dock.get(set_fleetid);
-                        if (set_dockdto != null) {
-                            set_dockdto.setUpdate(true);
-                        }
-                    }
-                }
-            }
-
-            addUpdateLog("他艦娘装備中装備の交換後、装備状態を更新しました");
-        } catch (Exception e) {
-            LOG.get().warn("他艦娘装備中装備の交換後、装備状態の更新に失敗しました", e);
-            LOG.get().warn(data);
-        }
-    }
-
-    /**
      * 艦娘ロックを更新する
      *
      * @param data

--- a/main/logbook/data/context/GlobalContext.java
+++ b/main/logbook/data/context/GlobalContext.java
@@ -699,10 +699,6 @@ public final class GlobalContext {
             case SLOT_EXCHANGE_INDEX:
                 doSlotExchangeIndex(data, apidata);
                 break;
-            // 他艦娘装備中装備交換
-            case SLOT_DEPRIVE:
-                doSlotDeprive(data, apidata);
-                break;
             // 艦娘ロック操作
             case LOCK_SHIP:
                 doLockShip(data, apidata);

--- a/main/logbook/util/ReportUtils.java
+++ b/main/logbook/util/ReportUtils.java
@@ -92,7 +92,6 @@ public class ReportUtils {
         case NYUKYO_START:
         case NYUKYO_SPEEDCHANGE:
         case SLOT_EXCHANGE_INDEX:
-        case SLOT_DEPRIVE:
 
             // 戦闘結果を反映させるため戦闘でも更新
         case BATTLE:

--- a/main/logbook/util/ReportUtils.java
+++ b/main/logbook/util/ReportUtils.java
@@ -92,6 +92,7 @@ public class ReportUtils {
         case NYUKYO_START:
         case NYUKYO_SPEEDCHANGE:
         case SLOT_EXCHANGE_INDEX:
+        case SLOT_DEPRIVE:
 
             // 戦闘結果を反映させるため戦闘でも更新
         case BATTLE:

--- a/script/util_missioncheck.js
+++ b/script/util_missioncheck.js
@@ -79,7 +79,7 @@ function setFleet(fleetid) {
 
 			if((ships[i].slot[j].match(/^九八式水上偵察機\(夜偵\)$/)) || (ships[i].slot[j].match(/^OS2U$/)) || (ships[i].slot[j].match(/^二式大艇$/)) || (ships[i].slot[j].match(/^Ro.44水上戦闘機$/)) || (ships[i].slot[j].match(/^二式水戦改$/)) || (ships[i].slot[j].match(/^Ro.44水上戦闘機bis$/)) || (ships[i].slot[j].match(/^二式水戦改\(熟練\)$/))) {
 				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 1;
-			} else if ((ships[i].slot[j].match(/^Lat$/)) || (ships[i].slot[j].match(/^瑞雲\(六三一空\)$/)) || (ships[i].slot[j].match(/^Ro.43水偵$/)) || (ships[i].slot[j].match(/^零式水上偵察機$/)) || (ships[i].slot[j].match(/^紫雲$/)) || (ships[i].slot[j].match(/^PBY-5A Catalina$/))){
+			} else if ((ships[i].slot[j].match(/^Lat/)) || (ships[i].slot[j].match(/^瑞雲\(六三一空\)$/)) || (ships[i].slot[j].match(/^Ro.43水偵$/)) || (ships[i].slot[j].match(/^零式水上偵察機$/)) || (ships[i].slot[j].match(/^紫雲$/)) || (ships[i].slot[j].match(/^PBY-5A Catalina$/))){
 				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 2;
 			} else if (ships[i].slot[j].match(/^晴嵐\(六三一空\)$/)) {
 				currentDockData.sumMinusTaisen = currentDockData.sumMinusTaisen + 3;
@@ -124,11 +124,11 @@ function setFleet(fleetid) {
 			case 20: currentDockData.ASCount++; break;
 			case 21: currentDockData.TVCount++; break;
 		}
-		if ((ships[i].stype == 7) && (!(ships[i].name.match(/^大鷹$/))))
+		if ((ships[i].stype == 7) && (!(ships[i].name.match(/^大鷹/))))
 		{
 			currentDockData.CVLCount++;
 		}
-		else if ((ships[i].stype == 7) && (ships[i].name.match(/^大鷹$/)))
+		else if ((ships[i].stype == 7) && (ships[i].name.match(/^大鷹/)))
 		{
 			currentDockData.ECCount++;
 		}


### PR DESCRIPTION
艦娘の装備していたアイテムが艦の解体時に自動的に取り外された際、実行の必要な処理がもしあれば付け足して頂きますようお願いいたします。